### PR TITLE
Mark model fields, that can be missing from the JSON output, as optional

### DIFF
--- a/src/model/caption.rs
+++ b/src/model/caption.rs
@@ -11,7 +11,7 @@ pub struct AutomaticCaption {
     /// The URL of the caption file.
     pub url: String,
     /// The language of the caption file, e.g. 'English'.
-    pub name: String,
+    pub name: Option<String>,
 }
 
 /// The available extensions for automatic caption files.

--- a/src/model/mod.rs
+++ b/src/model/mod.rs
@@ -34,8 +34,8 @@ pub struct Video {
     pub view_count: i64,
     /// The number of likes the video has. None, when the author has hidden it.
     pub like_count: Option<i64>,
-    /// The number of comments the video has.
-    pub comment_count: i64,
+    /// The number of comments the video has. None, when the author has disabled comments.
+    pub comment_count: Option<i64>,
 
     /// The channel display name.
     pub channel: String,

--- a/src/model/mod.rs
+++ b/src/model/mod.rs
@@ -32,8 +32,8 @@ pub struct Video {
 
     /// The number of views the video has.
     pub view_count: i64,
-    /// The number of likes the video has.
-    pub like_count: i64,
+    /// The number of likes the video has. None, when the author has hidden it.
+    pub like_count: Option<i64>,
     /// The number of comments the video has.
     pub comment_count: i64,
 


### PR DESCRIPTION
Resolves #6.

I searched for a specification of the JSON output and found the [output template section](https://github.com/yt-dlp/yt-dlp/blob/b83ca24eb72e1e558b0185bd73975586c0bc0546/README.md#output-template) of yt-dlp docs. However, it does not mention, that some fields can be null, so one cannot rely on it. So I guess there are more potentially optional fields, but I'm not aware of any effective way to discover them.

With these changes, I don't know of any video, that would cause a parsing error.

These are API-breaking changes, and so should appear in a new major version.

Tried to follow your commit message style. :)