### PR TITLE
Mark the video channel follower count field as optional

### DIFF
--- a/src/model/mod.rs
+++ b/src/model/mod.rs
@@ -44,7 +44,7 @@ pub struct Video {
     /// The URL of the channel.
     pub channel_url: String,
     /// The number of subscribers the channel has.
-    pub channel_follower_count: i64,
+    pub channel_follower_count: Option<i64>,
 
     /// The available formats of the video.
     pub formats: Vec<Format>,


### PR DESCRIPTION
Same as #7. Resolves #11.