### PR TITLE
Add rustls feature option

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,12 +29,14 @@ pre-release-replacements = [
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [features]
+default = ["reqwest/default"]
 tracing = ["dep:tracing"]
+rustls = ["reqwest/rustls-tls"]
 
 [dependencies]
 # Runtime and async dependencies
 tokio = { version = "1.41.1", features = ["rt-multi-thread", "macros", "fs", "time", "process"], default-features = false }
-reqwest = { version = "0.12.9", features = ["json", "stream"] }
+reqwest = { version = "0.12.9", features = ["json", "stream"], default-features = false}
 rusqlite = { version = "0.34.0", features = ["bundled"] }
 futures-util = "0.3.31"
 


### PR DESCRIPTION
The option to use rustls-tls for reqwest would be nice. rustls can be built more easily on systems where openssl sources aren't readily available.