### PR TITLE
Add rustls feature documentation, string split iterator improvements

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -36,7 +36,7 @@ rustls = ["reqwest/rustls-tls"]
 [dependencies]
 # Runtime and async dependencies
 tokio = { version = "1.41.1", features = ["rt-multi-thread", "macros", "fs", "time", "process"], default-features = false }
-reqwest = { version = "0.12.9", features = ["json", "stream"], default-features = false}
+reqwest = { version = "0.12.9", features = ["json", "stream"], default-features = false }
 rusqlite = { version = "0.34.0", features = ["bundled"] }
 futures-util = "0.3.31"
 

--- a/README.md
+++ b/README.md
@@ -94,6 +94,8 @@ available.
 
 - **`tracing`** — <img align="center" width="20" alt="Tracing" src="https://raw.githubusercontent.com/tokio-rs/tracing/refs/heads/master/assets/logo.svg" /> Enables profiling with the [```tracing```](https://crates.io/crates/tracing) crate.
   When this feature is enabled, the library will output span events at log levels `trace` and `debug`, depending on the importance of the called function.
+- **`rustls`** - Enables the `rustls-tls` feature in the [```reqwest```](https://crates.io/crates/reqwest) crate.
+  This enables building the application without openssl or other system sourced SSL libraries.
 
 #### 📝 Profiling with `tracing` (disabled by default):
 The crate supports the `tracing` feature to enable profiling, which can be useful for debugging.

--- a/src/fetcher/deps/ffmpeg.rs
+++ b/src/fetcher/deps/ffmpeg.rs
@@ -134,7 +134,7 @@ impl BuildFetcher {
         match (platform, architecture) {
             (Platform::Windows, _) => {
                 let url = Url::windows().to_string();
-                let name = url.split('/').last()?.to_string();
+                let name = url.split('/').next_back()?.to_string();
                 Some(Asset {
                     name,
                     download_url: url,
@@ -143,7 +143,7 @@ impl BuildFetcher {
 
             (Platform::Mac, Architecture::X64) => {
                 let url = Url::macos_intel().to_string();
-                let name = url.split('/').last()?.to_string();
+                let name = url.split('/').next_back()?.to_string();
                 Some(Asset {
                     name,
                     download_url: url,
@@ -151,7 +151,7 @@ impl BuildFetcher {
             }
             (Platform::Mac, Architecture::Aarch64) => {
                 let url = Url::macos_arm().to_string();
-                let name = url.split('/').last()?.to_string();
+                let name = url.split('/').next_back()?.to_string();
                 Some(Asset {
                     name,
                     download_url: url,
@@ -160,7 +160,7 @@ impl BuildFetcher {
 
             (Platform::Linux, Architecture::X64) => {
                 let url = Url::linux("amd64");
-                let name = url.split('/').last()?.to_string();
+                let name = url.split('/').next_back()?.to_string();
                 Some(Asset {
                     name,
                     download_url: url,
@@ -168,7 +168,7 @@ impl BuildFetcher {
             }
             (Platform::Linux, Architecture::X86) => {
                 let url = Url::linux("i686");
-                let name = url.split('/').last()?.to_string();
+                let name = url.split('/').next_back()?.to_string();
                 Some(Asset {
                     name,
                     download_url: url,
@@ -176,7 +176,7 @@ impl BuildFetcher {
             }
             (Platform::Linux, Architecture::Armv7l) => {
                 let url = Url::linux("armhf");
-                let name = url.split('/').last()?.to_string();
+                let name = url.split('/').next_back()?.to_string();
                 Some(Asset {
                     name,
                     download_url: url,
@@ -184,7 +184,7 @@ impl BuildFetcher {
             }
             (Platform::Linux, Architecture::Aarch64) => {
                 let url = Url::linux("arm64");
-                let name = url.split('/').last()?.to_string();
+                let name = url.split('/').next_back()?.to_string();
                 Some(Asset {
                     name,
                     download_url: url,


### PR DESCRIPTION
- Fixes the clippy errors identified [in this build job](https://github.com/boul2gom/yt-dlp/actions/runs/14301926501/job/40077702397) related to using ```.last()``` on a double-ended iterator rather than ```.next_back()```
- Added section to readme documenting the rustls feature added in 8c59903
- Fixed a missing space in `Cargo.toml` (I saved without formatting as the default format configuration went to town and I didn't want to change too much, but I missed adding that space myself!)