### PR TITLE
feat: partial support for twitch

### DIFF
--- a/src/executor/mod.rs
+++ b/src/executor/mod.rs
@@ -99,20 +99,24 @@ impl Executor {
         });
 
         // Wait for the process to finish with timeout
-        let exit_status = match tokio::time::timeout(self.timeout, child.wait()).await {
-            Ok(result) => result?,
-            Err(_) => {
-                // In case of timeout, kill the process and all its children
-                #[cfg(feature = "tracing")]
-                tracing::warn!("Process timed out after {:?}, killing it", self.timeout);
-
-                // Try to kill the process
-                if let Err(_e) = child.kill().await {
+        let exit_status = if self.timeout == Duration::default() {
+            child.wait().await?
+        } else {
+            match tokio::time::timeout(self.timeout, child.wait()).await {
+                Ok(result) => result?,
+                Err(_) => {
+                    // In case of timeout, kill the process and all its children
                     #[cfg(feature = "tracing")]
-                    tracing::error!("Failed to kill process after timeout: {}", _e);
-                }
+                    tracing::warn!("Process timed out after {:?}, killing it", self.timeout);
 
-                return Err(Error::Timeout(self.timeout));
+                    // Try to kill the process
+                    if let Err(_e) = child.kill().await {
+                        #[cfg(feature = "tracing")]
+                        tracing::error!("Failed to kill process after timeout: {}", _e);
+                    }
+
+                    return Err(Error::Timeout(self.timeout));
+                }
             }
         };
 

--- a/src/metadata/mod.rs
+++ b/src/metadata/mod.rs
@@ -52,9 +52,9 @@ pub trait BaseMetadata {
 
         let mut metadata = vec![
             ("title".to_string(), video.title.clone()),
-            ("artist".to_string(), video.channel.clone()),
-            ("album_artist".to_string(), video.channel.clone()),
-            ("album".to_string(), video.channel.clone()),
+            ("artist".to_string(), video.uploader.clone()),
+            ("album_artist".to_string(), video.uploader.clone()),
+            ("album".to_string(), video.uploader.clone()),
         ];
 
         // Add tags as genre

--- a/src/model/format.rs
+++ b/src/model/format.rs
@@ -78,13 +78,16 @@ impl Format {
         format_type.is_audio()
     }
 
+    /// Checks if the format is a manifest.
+    pub fn is_manifest(&self) -> bool {
+        let format_type = self.format_type();
+
+        format_type.is_manifest()
+    }
+
     /// Gets the type of the format.
     /// It can be audio, video, both of them, a manifest, or a storyboard.
     pub fn format_type(&self) -> FormatType {
-        if self.download_info.manifest_url.is_some() {
-            return FormatType::Manifest;
-        }
-
         if self.storyboard_info.fragments.is_some() {
             return FormatType::Storyboard;
         }
@@ -92,11 +95,15 @@ impl Format {
         let audio = self.codec_info.audio_codec.is_some();
         let video = self.codec_info.video_codec.is_some();
 
+        if self.download_info.manifest_url.is_some() {
+            return FormatType::Manifest { audio, video };
+        }
+
         match (audio, video) {
             (true, true) => FormatType::AudioVideo,
             (true, false) => FormatType::Audio,
             (false, true) => FormatType::Video,
-            _ => FormatType::Manifest,
+            _ => FormatType::Manifest { audio, video },
         }
     }
 }
@@ -497,7 +504,7 @@ pub enum FormatType {
     /// The format contains both audio and video.
     AudioVideo,
     /// The format is a manifest.
-    Manifest,
+    Manifest { audio: bool, video: bool },
     /// The format is a storyboard.
     Storyboard,
 
@@ -516,7 +523,7 @@ impl fmt::Display for FormatType {
                 FormatType::Audio => "Audio",
                 FormatType::Video => "Video",
                 FormatType::AudioVideo => "AudioVideo",
-                FormatType::Manifest => "Manifest",
+                FormatType::Manifest { .. } => "Manifest",
                 FormatType::Storyboard => "Storyboard",
                 FormatType::Unknown => "Unknown",
             }
@@ -527,17 +534,30 @@ impl fmt::Display for FormatType {
 impl FormatType {
     /// Checks if the format is an audio and video format.
     pub fn is_audio_and_video(&self) -> bool {
-        matches!(self, FormatType::AudioVideo)
+        matches!(
+            self,
+            FormatType::AudioVideo
+                | FormatType::Manifest {
+                    audio: true,
+                    video: true
+                }
+        )
     }
 
     /// Checks if the format is a video format.
     pub fn is_video(&self) -> bool {
-        matches!(self, FormatType::Video)
+        matches!(
+            self,
+            FormatType::Video | FormatType::AudioVideo | FormatType::Manifest { video: true, .. }
+        )
     }
 
     /// Checks if the format is an audio format.
     pub fn is_audio(&self) -> bool {
-        matches!(self, FormatType::Audio)
+        matches!(
+            self,
+            FormatType::Audio | FormatType::AudioVideo | FormatType::Manifest { audio: true, .. }
+        )
     }
 
     /// Checks if the format is a storyboard format.
@@ -547,6 +567,6 @@ impl FormatType {
 
     /// Checks if the format is a manifest format.
     pub fn is_manifest(&self) -> bool {
-        matches!(self, FormatType::Manifest)
+        matches!(self, FormatType::Manifest { .. })
     }
 }

--- a/src/model/mod.rs
+++ b/src/model/mod.rs
@@ -6,6 +6,7 @@ use crate::model::caption::AutomaticCaption;
 use crate::model::format::Format;
 use crate::model::format_selector::{matches_audio_codec, matches_video_codec};
 use crate::model::thumbnail::Thumbnail;
+use crate::utils::null_to_default;
 use ordered_float::OrderedFloat;
 use serde::{Deserialize, Serialize};
 use std::cmp::Ordering;
@@ -33,8 +34,10 @@ pub struct Video {
     /// The thumbnail URL of the video, usually the highest quality.
     pub thumbnail: String,
     /// The description of the video.
+    #[serde(deserialize_with = "null_to_default")]
     pub description: String,
     /// If the video is public, unlisted, or private.
+    #[serde(default)]
     pub availability: String,
     /// The upload date of the video.
     #[serde(rename = "timestamp")]
@@ -48,11 +51,12 @@ pub struct Video {
     pub comment_count: Option<i64>,
 
     /// The channel display name.
-    pub channel: String,
+    pub uploader: String,
     /// The channel ID, not the @username.
-    pub channel_id: String,
+    pub uploader_id: String,
     /// The URL of the channel.
-    pub channel_url: String,
+    #[serde(default)]
+    pub uploader_url: String,
     /// The number of subscribers the channel has.
     pub channel_follower_count: Option<i64>,
 
@@ -61,14 +65,18 @@ pub struct Video {
     /// The thumbnails of the video.
     pub thumbnails: Vec<Thumbnail>,
     /// The automatic captions of the video.
+    #[serde(default = "HashMap::new")]
     pub automatic_captions: HashMap<String, Vec<AutomaticCaption>>,
 
     /// The tags of the video.
+    #[serde(default)]
     pub tags: Vec<String>,
     /// The categories of the video.
+    #[serde(default)]
     pub categories: Vec<String>,
 
     /// If the video is age restricted, the age limit is different from 0.
+    #[serde(default)]
     pub age_limit: i64,
     /// If the video is available in the country.
     #[serde(rename = "_has_drm")]
@@ -76,7 +84,7 @@ pub struct Video {
     /// If the video was a live stream.
     pub live_status: String,
     /// If the video is playable in an embed.
-    pub playable_in_embed: bool,
+    pub playable_in_embed: Option<bool>,
 
     /// The extractor information.
     #[serde(flatten)]
@@ -84,6 +92,7 @@ pub struct Video {
     /// The version of 'yt-dlp' used to fetch the video.
     #[serde(rename = "_version")]
     pub version: Version,
+    pub filename: String,
 }
 
 /// Represents the extractor information.
@@ -198,7 +207,17 @@ impl Video {
         let a_vbr = a.rates_info.video_rate.map(|vr| *vr).unwrap_or(0.0);
         let b_vbr = b.rates_info.video_rate.map(|vr| *vr).unwrap_or(0.0);
 
-        OrderedFloat(a_vbr).cmp(&OrderedFloat(b_vbr))
+        let cmp_vbr = OrderedFloat(a_vbr).cmp(&OrderedFloat(b_vbr));
+        if cmp_vbr != std::cmp::Ordering::Equal {
+            return cmp_vbr;
+        }
+
+        match (a.is_manifest(),b.is_manifest()) {
+            (true, true)|(false, false) => std::cmp::Ordering::Equal,
+            (true, false) => std::cmp::Ordering::Less,
+            (false, true) => std::cmp::Ordering::Greater,
+            
+        }
     }
 
     /// Compares two audio formats.
@@ -586,10 +605,10 @@ impl fmt::Display for Video {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         write!(
             f,
-            "Video(id = {}, title = \"{}\", channel = \"{}\", formats = {})",
+            "Video(id = {}, title = \"{}\", uploader = \"{}\", formats = {})",
             self.id,
             self.title,
-            self.channel,
+            self.uploader,
             self.formats.len()
         )
     }
@@ -627,8 +646,8 @@ impl std::hash::Hash for Video {
     fn hash<H: std::hash::Hasher>(&self, state: &mut H) {
         self.id.hash(state);
         self.title.hash(state);
-        self.channel.hash(state);
-        self.channel_id.hash(state);
+        self.uploader.hash(state);
+        self.uploader_id.hash(state);
     }
 }
 

--- a/src/model/thumbnail.rs
+++ b/src/model/thumbnail.rs
@@ -10,6 +10,7 @@ pub struct Thumbnail {
     /// The URL of the thumbnail.
     pub url: String,
     /// The preference index of the thumbnail, e.g. '-35' or '0'.
+    #[serde(default)]
     pub preference: i64,
 
     /// The ID of the thumbnail.

--- a/src/utils/mod.rs
+++ b/src/utils/mod.rs
@@ -4,6 +4,7 @@
 
 use crate::error::Result;
 use platform::Platform;
+use serde::{Deserialize, Deserializer};
 use tokio::task::JoinHandle;
 
 pub mod file_system;
@@ -71,4 +72,15 @@ macro_rules! ternary {
     ($condition:expr, $true:expr, $false:expr) => {
         if $condition { $true } else { $false }
     };
+}
+
+/// Null handling in serde
+pub fn null_to_default<'de, D, T>(d: D) -> ::std::result::Result<T, D::Error>
+where
+    D: Deserializer<'de>,
+    T: Default + Deserialize<'de>,
+{
+    let opt = Option::deserialize(d)?;
+    let val = opt.unwrap_or_else(T::default);
+    Ok(val)
 }


### PR DESCRIPTION
This allows us to get the video info from twitch and select a manifest format that best matches the quality preferences. It is, however, missing a way to download and convert the `.ts` files referenced in the `m3u8` manifests to other video/audio formats.

I haven't tested it for other extractors yet, and supporting them may require further changes to the `Video` struct.