### PR TITLE
Represent DRM protection with an enum containing a "maybe" variant

### DIFF
--- a/src/model/format.rs
+++ b/src/model/format.rs
@@ -5,6 +5,7 @@ use ordered_float::OrderedFloat;
 use serde::{Deserialize, Serialize};
 use std::fmt;
 use std::hash::Hash;
+use crate::model::has_drm::HasDrm;
 
 /// Represents an available format of a video.
 /// It can be audio, video, both of them, a manifest, or a storyboard.
@@ -29,7 +30,7 @@ pub struct Format {
     pub language: Option<String>,
 
     /// If the format has DRM.
-    pub has_drm: Option<bool>,
+    pub has_drm: Option<HasDrm>,
     /// The extension of the file containing the format.
     #[serde(default)]
     pub container: Option<Container>,

--- a/src/model/has_drm.rs
+++ b/src/model/has_drm.rs
@@ -1,0 +1,41 @@
+use serde::{Deserialize, Deserializer, Serialize, Serializer};
+use serde_json::Value;
+
+/// Represents whether content is protected by digital rights management.
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+pub enum HasDrm {
+    /// Is protected by DRM and cannot be downloaded.
+    Yes,
+    /// May be protected by DRM and has to be tested before download.
+    Maybe,
+    /// Is not protected by DRM.
+    No,
+}
+
+impl Serialize for HasDrm {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        match self {
+            HasDrm::Yes => serializer.serialize_bool(true),
+            HasDrm::Maybe => serializer.serialize_str("maybe"),
+            HasDrm::No => serializer.serialize_bool(false),
+        }
+    }
+}
+
+impl<'de> Deserialize<'de> for HasDrm {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        let value = Value::deserialize(deserializer)?;
+        match value {
+            Value::Bool(true) => Ok(HasDrm::Yes),
+            Value::String(s) if s == "maybe" => Ok(HasDrm::Maybe),
+            Value::Bool(false) => Ok(HasDrm::No),
+            _ => Err(serde::de::Error::custom("Invalid value for the `HasDrm` type. Expected a boolean or \"maybe\".")),
+        }
+    }
+}

--- a/src/model/mod.rs
+++ b/src/model/mod.rs
@@ -17,11 +17,13 @@ pub mod format;
 pub mod format_selector;
 pub mod thumbnail;
 pub mod utils;
+pub mod has_drm;
 
 // Re-export traits for easier access
 pub use utils::{AllTraits, CommonTraits};
 // Re-export format selectors for easier access
 pub use format_selector::{AudioCodecPreference, AudioQuality, VideoCodecPreference, VideoQuality};
+use has_drm::HasDrm;
 
 /// Represents a YouTube video, the output of 'yt-dlp'.
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
@@ -72,7 +74,7 @@ pub struct Video {
     pub age_limit: i64,
     /// If the video is available in the country.
     #[serde(rename = "_has_drm")]
-    pub has_drm: Option<bool>,
+    pub has_drm: Option<HasDrm>,
     /// If the video was a live stream.
     pub live_status: String,
     /// If the video is playable in an embed.


### PR DESCRIPTION
Resolves #50. According to the [yt-dlp docs](https://github.com/yt-dlp/yt-dlp/blob/c723c4e5e78263df178dbe69844a3d05f3ef9e35/yt_dlp/extractor/common.py#L240), true, false and "maybe" are the only possible values.

This is an **API-breaking change**, and so (according to semver) should be a part of a new **major** release.