### PR TITLE
Fix: deserialization errors caused by updated YouTube API format

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -72,3 +72,4 @@ rand = "0.9.2"
 # Logging dependencies
 tracing = { version = "0.1.41", optional = true }
 cfg-if = "1.0.4"
+serde_with = "3.16.0"

--- a/src/model/caption.rs
+++ b/src/model/caption.rs
@@ -21,6 +21,7 @@ pub struct AutomaticCaption {
 #[serde(rename_all = "snake_case")]
 pub enum Extension {
     /// The JSON extension.
+    Json,
     Json3,
     /// The Srv1 extension.
     Srv1,
@@ -68,6 +69,7 @@ impl Hash for AutomaticCaption {
 impl fmt::Display for Extension {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
+            Extension::Json => write!(f, "json"),
             Extension::Json3 => write!(f, "json3"),
             Extension::Srv1 => write!(f, "srv1"),
             Extension::Srv2 => write!(f, "srv2"),
@@ -95,7 +97,7 @@ impl Hash for Extension {
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub struct Subtitle {
     /// The language code of the subtitle (e.g., 'en', 'fr', 'es').
-    pub language_code: String,
+    pub language_code: Option<String>,
     /// The full language name (e.g., 'English', 'French', 'Spanish').
     pub language_name: Option<String>,
     /// The URL of the subtitle file.
@@ -112,7 +114,7 @@ impl Subtitle {
     /// Creates a new Subtitle from an AutomaticCaption.
     pub fn from_automatic_caption(caption: &AutomaticCaption, language_code: String) -> Self {
         Self {
-            language_code,
+            language_code: Some(language_code),
             language_name: caption.name.clone(),
             url: caption.url.clone(),
             extension: caption.extension.clone(),
@@ -128,6 +130,7 @@ impl Subtitle {
     /// Returns the file extension as a string.
     pub fn file_extension(&self) -> &str {
         match self.extension {
+            Extension::Json => "json",
             Extension::Json3 => "json3",
             Extension::Srv1 => "srv1",
             Extension::Srv2 => "srv2",
@@ -147,7 +150,10 @@ impl fmt::Display for Subtitle {
         write!(
             f,
             "Subtitle(lang={}, format={}, auto={})",
-            self.language_name.as_deref().unwrap_or(&self.language_code),
+            self.language_name
+                .as_deref()
+                .or(self.language_code.as_deref())
+                .unwrap_or("unknown"),
             self.file_extension(),
             self.is_automatic
         )

--- a/src/model/heatmap.rs
+++ b/src/model/heatmap.rs
@@ -4,11 +4,9 @@ use serde::{Deserialize, Serialize};
 use std::fmt;
 use std::hash::{Hash, Hasher};
 
-/// Represents a point in a video heatmap.
-/// Heatmaps show viewer engagement across different segments of a video,
-/// commonly known as "Most Replayed" segments on YouTube.
+/// Represents the complete heatmap data for a video.
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
-pub struct HeatmapPoint {
+pub struct Heatmap {
     /// The start time of this heatmap segment in seconds.
     pub start_time: f64,
     /// The end time of this heatmap segment in seconds.
@@ -18,7 +16,7 @@ pub struct HeatmapPoint {
     pub value: f64,
 }
 
-impl HeatmapPoint {
+impl Heatmap {
     /// Returns the duration of this heatmap segment in seconds.
     pub fn duration(&self) -> f64 {
         self.end_time - self.start_time
@@ -30,58 +28,8 @@ impl HeatmapPoint {
     }
 }
 
-/// Represents the complete heatmap data for a video.
-#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
-pub struct Heatmap {
-    /// The collection of heatmap points covering the video timeline.
-    pub points: Vec<HeatmapPoint>,
-}
-
-impl Heatmap {
-    /// Returns the heatmap point with the highest engagement value.
-    /// This represents the most replayed segment of the video.
-    pub fn most_engaged_segment(&self) -> Option<&HeatmapPoint> {
-        self.points.iter().max_by(|a, b| {
-            a.value
-                .partial_cmp(&b.value)
-                .unwrap_or(std::cmp::Ordering::Equal)
-        })
-    }
-
-    /// Returns the heatmap point at a specific timestamp.
-    ///
-    /// # Arguments
-    ///
-    /// * `timestamp` - The timestamp in seconds
-    ///
-    /// # Returns
-    ///
-    /// The heatmap point containing the timestamp, or None if no point matches
-    pub fn get_point_at_time(&self, timestamp: f64) -> Option<&HeatmapPoint> {
-        self.points
-            .iter()
-            .find(|point| point.contains_timestamp(timestamp))
-    }
-
-    /// Returns all heatmap points with an engagement value above the threshold.
-    ///
-    /// # Arguments
-    ///
-    /// * `threshold` - The minimum engagement value (0.0 to 1.0)
-    ///
-    /// # Returns
-    ///
-    /// A vector of references to highly engaged segments
-    pub fn get_highly_engaged_segments(&self, threshold: f64) -> Vec<&HeatmapPoint> {
-        self.points
-            .iter()
-            .filter(|point| point.value >= threshold)
-            .collect()
-    }
-}
-
-// Implementation of the Display trait for HeatmapPoint
-impl fmt::Display for HeatmapPoint {
+// Implementation of the Display trait for Heatmap
+impl fmt::Display for Heatmap {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         write!(
             f,
@@ -91,33 +39,14 @@ impl fmt::Display for HeatmapPoint {
     }
 }
 
-// Implementation of the Display trait for Heatmap
-impl fmt::Display for Heatmap {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        write!(f, "Heatmap(points={})", self.points.len())
-    }
-}
-
-// Implementation of Eq for HeatmapPoint
-impl Eq for HeatmapPoint {}
-
 // Implementation of Eq for Heatmap
 impl Eq for Heatmap {}
 
 // Implementation of Hash for HeatmapPoint
-impl Hash for HeatmapPoint {
+impl Hash for Heatmap {
     fn hash<H: Hasher>(&self, state: &mut H) {
         self.start_time.to_bits().hash(state);
         self.end_time.to_bits().hash(state);
         self.value.to_bits().hash(state);
-    }
-}
-
-// Implementation of Hash for Heatmap
-impl Hash for Heatmap {
-    fn hash<H: Hasher>(&self, state: &mut H) {
-        for point in &self.points {
-            point.hash(state);
-        }
     }
 }

--- a/src/model/heatmap.rs
+++ b/src/model/heatmap.rs
@@ -2,11 +2,13 @@
 
 use serde::{Deserialize, Serialize};
 use std::fmt;
-use std::hash::{Hash, Hasher};
+
+#[derive(Debug, Clone, Default, Serialize, Deserialize, PartialEq)]
+pub struct Heatmap(pub Vec<HeatmapPoint>);
 
 /// Represents the complete heatmap data for a video.
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
-pub struct Heatmap {
+pub struct HeatmapPoint {
     /// The start time of this heatmap segment in seconds.
     pub start_time: f64,
     /// The end time of this heatmap segment in seconds.
@@ -17,6 +19,62 @@ pub struct Heatmap {
 }
 
 impl Heatmap {
+    fn points(&self) -> &[HeatmapPoint] {
+        &self.0
+    }
+
+    /// Returns the heatmap point with the highest engagement value.
+    /// This represents the most replayed segment of the video.
+    pub fn most_engaged_segment(&self) -> Option<&HeatmapPoint> {
+        self.points().iter().max_by(|a, b| {
+            a.value
+                .partial_cmp(&b.value)
+                .unwrap_or(std::cmp::Ordering::Equal)
+        })
+    }
+
+    /// Returns all heatmap points with an engagement value above the threshold.
+    ///
+    /// # Arguments
+    ///
+    /// * `threshold` - The minimum engagement value (0.0 to 1.0)
+    ///
+    /// # Returns
+    ///
+    /// A vector of references to highly engaged segments
+    pub fn get_highly_engaged_segments(&self, threshold: f64) -> Vec<&HeatmapPoint> {
+        self.points()
+            .iter()
+            .filter(|p| p.value >= threshold)
+            .collect()
+    }
+
+    /// Returns the heatmap point at a specific timestamp.
+    ///
+    /// # Arguments
+    ///
+    /// * `timestamp` - The timestamp in seconds
+    ///
+    /// # Returns
+    ///
+    /// The heatmap point containing the timestamp, or None if no point matches
+    pub fn get_point_at_time(&self, timestamp: f64) -> Option<&HeatmapPoint> {
+        self.points()
+            .iter()
+            .find(|p| p.contains_timestamp(timestamp))
+    }
+
+    /// Checks if the heatmap is empty.
+    ///
+    /// # Returns
+    ///
+    /// True if the heatmap is empty, false otherwise
+    pub fn is_empty(&self) -> bool {
+        self.0.is_empty()
+    }
+}
+
+impl HeatmapPoint {
     /// Returns the duration of this heatmap segment in seconds.
     pub fn duration(&self) -> f64 {
         self.end_time - self.start_time
@@ -28,25 +86,13 @@ impl Heatmap {
     }
 }
 
-// Implementation of the Display trait for Heatmap
-impl fmt::Display for Heatmap {
+// Implementation of the Display trait for HeatmapPoint
+impl fmt::Display for HeatmapPoint {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         write!(
             f,
             "HeatmapPoint(start={:.2}s, end={:.2}s, value={:.2})",
             self.start_time, self.end_time, self.value
         )
-    }
-}
-
-// Implementation of Eq for Heatmap
-impl Eq for Heatmap {}
-
-// Implementation of Hash for HeatmapPoint
-impl Hash for Heatmap {
-    fn hash<H: Hasher>(&self, state: &mut H) {
-        self.start_time.to_bits().hash(state);
-        self.end_time.to_bits().hash(state);
-        self.value.to_bits().hash(state);
     }
 }

--- a/src/model/mod.rs
+++ b/src/model/mod.rs
@@ -60,10 +60,11 @@ impl<'de> Deserialize<'de> for DrmStatus {
             where
                 E: serde::de::Error,
             {
-                if value == "maybe" {
-                    Ok(DrmStatus::Maybe)
-                } else {
-                    Err(E::custom(format!("Expected \"maybe\", got \"{}\"", value)))
+                match value {
+                    "Yes" => Ok(DrmStatus::Yes),
+                    "No" => Ok(DrmStatus::No),
+                    "maybe" => Ok(DrmStatus::Maybe),
+                    _ => Err(E::custom(format!("Expected \"maybe\", got \"{}\"", value))),
                 }
             }
         }

--- a/src/model/video.rs
+++ b/src/model/video.rs
@@ -71,7 +71,7 @@ pub struct Video {
     pub chapters: Vec<Chapter>,
     /// The heatmap data for the video (most replayed segments).
     #[serde(default)]
-    pub heatmap: Option<Vec<Heatmap>>,
+    pub heatmap: Option<Heatmap>,
 
     /// The tags of the video.
     pub tags: Vec<String>,
@@ -449,7 +449,7 @@ impl Video {
     /// # Returns
     ///
     /// A reference to the heatmap, or None if no heatmap data is available
-    pub fn get_heatmap(&self) -> Option<&Vec<Heatmap>> {
+    pub fn get_heatmap(&self) -> Option<&Heatmap> {
         self.heatmap.as_ref()
     }
 

--- a/src/model/video.rs
+++ b/src/model/video.rs
@@ -14,6 +14,7 @@ use crate::model::selector::{
 use crate::model::thumbnail::Thumbnail;
 use ordered_float::OrderedFloat;
 use serde::{Deserialize, Serialize};
+use serde_with::{DefaultOnNull, serde_as};
 use std::cmp::Ordering;
 use std::collections::HashMap;
 use std::fmt;
@@ -22,6 +23,7 @@ use std::fmt;
 use super::DrmStatus;
 
 /// Represents a YouTube video, the output of 'yt-dlp'.
+#[serde_as]
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub struct Video {
     /// The ID of the video.
@@ -65,10 +67,11 @@ pub struct Video {
     pub subtitles: HashMap<String, Vec<Subtitle>>,
     /// The chapters of the video.
     #[serde(default)]
+    #[serde_as(deserialize_as = "DefaultOnNull")]
     pub chapters: Vec<Chapter>,
     /// The heatmap data for the video (most replayed segments).
     #[serde(default)]
-    pub heatmap: Option<Heatmap>,
+    pub heatmap: Option<Vec<Heatmap>>,
 
     /// The tags of the video.
     pub tags: Vec<String>,
@@ -427,7 +430,7 @@ impl Video {
     ///
     /// The chapter containing the timestamp, or None if no chapter matches
     pub fn get_chapter_at_time(&self, timestamp: f64) -> Option<&Chapter> {
-        self.chapters
+        self.get_chapters()
             .iter()
             .find(|chapter| chapter.contains_timestamp(timestamp))
     }
@@ -438,7 +441,7 @@ impl Video {
     ///
     /// true if the video has at least one chapter, false otherwise
     pub fn has_chapters(&self) -> bool {
-        !self.chapters.is_empty()
+        !self.get_chapters().is_empty()
     }
 
     /// Returns the heatmap data for the video if available.
@@ -446,7 +449,7 @@ impl Video {
     /// # Returns
     ///
     /// A reference to the heatmap, or None if no heatmap data is available
-    pub fn get_heatmap(&self) -> Option<&Heatmap> {
+    pub fn get_heatmap(&self) -> Option<&Vec<Heatmap>> {
         self.heatmap.as_ref()
     }
 


### PR DESCRIPTION
Structures have been adapted to the new YouTube response format. 

The following errors have been fixed:
```shell
Error: Json { context: "Failed to parse video metadata", source: Error("missing field `language_code`", line: 1, column: 591641) }
```
```shell
Error: Json { context: "Failed to parse video metadata", source: Error("unknown variant `json`, expected one of `json3`, `srv1`, `srv2`, `srv3`, `ttml`, `vtt`, `srt`, `ass`, `ssa`", line: 1, column: 598278) }
```
```shell
Error: Json { context: "Failed to parse video metadata", source: Error("invalid type: null, expected a sequence", line: 1, column: 598142) }
```
```shell
Error: Json { context: "Failed to parse video metadata", source: Error("invalid type: map, expected a sequence", line: 1, column: 62490) }
```
```shell
Error: Json { context: "Failed to parse video metadata", source: Error("missing field `points`", line: 1, column: 62306) }
```
```shell
Error: Unknown("Failed to parse video: invalid type: null, expected a sequence at line 1 column 1734")
```

Tested on video: https://www.youtube.com/watch?v=LYnhN_49tpE

This PR is partly related to #89, but it fixed not just one bug, but a whole bunch of issues.

Additionally, `serde_with` was added as a dependency to simplify deserialization of fields that can be null or missing in the API response.
Specifically, `DefaultOnNull` is used to provide default values (like empty Vec or HashMap) when the API returns null instead of a sequence or object, avoiding runtime deserialization errors and making the structs more robust against API changes.