### PR TITLE
Add live fragment streaming support with events, builders, and docs

### DIFF
--- a/.github/workflows/ci-dev.yml
+++ b/.github/workflows/ci-dev.yml
@@ -181,7 +181,7 @@ jobs:
         uses: dtolnay/rust-toolchain@631a55b12751854ce901bb631d5902ceb48146f7 # stable
 
       - name: 🔥 Compile all dependencies
-        run: cargo build --features "cache-memory,cache-json,hooks,webhooks,statistics,live-recording"
+        run: cargo build --features "cache-memory,cache-json,hooks,webhooks,statistics,live-recording,live-streaming"
 
       - name: 📦 Save compiled target directory
         uses: actions/cache/save@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.3.0
@@ -209,15 +209,15 @@ jobs:
             run_integration: true
           - name: full-json
             shared_key: "full-json"
-            cargo_features: "--features cache-memory,cache-json,hooks,webhooks,statistics,live-recording"
+            cargo_features: "--features cache-memory,cache-json,hooks,webhooks,statistics,live-recording,live-streaming"
             run_integration: true
           - name: full-redb
             shared_key: "full-redb"
-            cargo_features: "--features cache-memory,cache-redb,hooks,webhooks,statistics,live-recording"
+            cargo_features: "--features cache-memory,cache-redb,hooks,webhooks,statistics,live-recording,live-streaming"
             run_integration: true
           - name: full-redis
             shared_key: "full-redis"
-            cargo_features: "--features cache-memory,cache-redis,hooks,webhooks,statistics,live-recording"
+            cargo_features: "--features cache-memory,cache-redis,hooks,webhooks,statistics,live-recording,live-streaming"
             run_integration: false
 
     steps:
@@ -306,7 +306,7 @@ jobs:
         uses: dtolnay/rust-toolchain@631a55b12751854ce901bb631d5902ceb48146f7 # stable
 
       - name: 📚 Run doc tests
-        run: cargo test --doc --workspace --features "cache-memory,cache-json,hooks,webhooks,statistics,live-recording"
+        run: cargo test --doc --workspace --features "cache-memory,cache-json,hooks,webhooks,statistics,live-recording,live-streaming"
 
   integration-tests-redis:
     name: 🔗 Integration tests (cache-redis)
@@ -363,7 +363,7 @@ jobs:
       - name: 🔗 Run integration tests (cache-redis)
         env:
           REDIS_URL: redis://localhost:6379
-        run: cargo test --test integration --features "cache-memory,cache-redis,hooks,webhooks,statistics,live-recording"
+        run: cargo test --test integration --features "cache-memory,cache-redis,hooks,webhooks,statistics,live-recording,live-streaming"
 
   e2e-tests:
     name: 🚀 E2E tests
@@ -413,7 +413,7 @@ jobs:
           sudo apt-get install -y ffmpeg
 
       - name: 🚀 Run E2E tests
-        run: cargo test --test e2e --features "cache-memory,cache-json,hooks,webhooks,statistics,live-recording" -- --test-threads=1
+        run: cargo test --test e2e --features "cache-memory,cache-json,hooks,webhooks,statistics,live-recording,live-streaming" -- --test-threads=1
 
   analysis:
     name: 🔍 Static analysis
@@ -494,9 +494,9 @@ jobs:
       - name: 📊 Generate coverage (unit + integration + e2e)
         run: |
           cargo llvm-cov clean --workspace
-          cargo llvm-cov --no-report --test unit --features "cache-memory,cache-json,hooks,webhooks,statistics,live-recording"
-          cargo llvm-cov --no-report --test integration --features "cache-memory,cache-json,hooks,webhooks,statistics,live-recording"
-          cargo llvm-cov --no-report --test e2e --features "cache-memory,cache-json,hooks,webhooks,statistics,live-recording" -- --test-threads=1
+          cargo llvm-cov --no-report --test unit --features "cache-memory,cache-json,hooks,webhooks,statistics,live-recording,live-streaming"
+          cargo llvm-cov --no-report --test integration --features "cache-memory,cache-json,hooks,webhooks,statistics,live-recording,live-streaming"
+          cargo llvm-cov --no-report --test e2e --features "cache-memory,cache-json,hooks,webhooks,statistics,live-recording,live-streaming" -- --test-threads=1
           cargo llvm-cov report --lcov --output-path lcov.info
 
       - name: 📦 Upload coverage to Codecov

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -157,7 +157,7 @@ src/
 │       ├── json.rs     # JSON file (L2)
 │       ├── redb.rs     # Embedded redb (L2)
 │       └── redis.rs    # Distributed Redis (L2)
-├── live/               # Live stream recording (feature: live-recording)
+├── live/               # Live recording/streaming (features: live-recording, live-streaming)
 │   ├── hls.rs          # HLS manifest parsing via m3u8-rs
 │   ├── recording.rs    # LiveRecorder — reqwest-based HLS segment recorder (primary)
 │   └── ffmpeg_recording.rs  # FfmpegLiveRecorder — FFmpeg-based recorder (fallback)
@@ -398,6 +398,7 @@ Features in `Cargo.toml`:
 - `hooks`, `webhooks`, `statistics` — zero-dependency feature flags.
 - **Cache hierarchy**: `cache-memory` (Moka in-memory), `cache-json` (JSON files), `cache-redb` (embedded redb), `cache-redis` (distributed Redis). The `cache` cfg is emitted by `build.rs` when any of these is enabled.
 - `live-recording` — live stream recording via HLS (pulls `m3u8-rs`).
+- `live-streaming` — live fragment streaming via HLS (pulls `m3u8-rs`).
 - `rustls` — optional TLS backend.
 - `hickory-dns` — optional async DNS resolver (passes `reqwest/hickory-dns`).
 - `profiling` — optional `dhat` heap profiler.
@@ -413,7 +414,8 @@ Usage patterns:
 - `#[cfg(feature = "cache-json")]` — backend-specific module declarations and imports.
 - `#[cfg(persistent_cache)]` — guard for any persistent backend code.
 - `#[cfg(feature = "hooks")]` — module declarations, struct fields, `pub use` exports.
-- `#[cfg(feature = "live-recording")]` — live recording module, error variants, event variants, executor streaming.
+- `#[cfg(feature = "live-recording")]` — live recording module, error variants, recording events, executor streaming.
+- `#[cfg(feature = "live-streaming")]` — live streaming events and fragment streaming API.
 
 HTTP Client Configuration
 
@@ -584,17 +586,17 @@ Verification
 All edits must pass these checks:
 ```bash
 # Lint feature-complete builds (covers both yt-dlp and media-seek)
-cargo clippy --workspace --features cache-memory,cache-json,hooks,webhooks,statistics,live-recording -- -D warnings
-cargo clippy --workspace --features cache-memory,cache-redb,hooks,webhooks,statistics,live-recording -- -D warnings
-cargo clippy --workspace --features cache-memory,cache-redis,hooks,webhooks,statistics,live-recording -- -D warnings
+cargo clippy --workspace --features cache-memory,cache-json,hooks,webhooks,statistics,live-recording,live-streaming -- -D warnings
+cargo clippy --workspace --features cache-memory,cache-redb,hooks,webhooks,statistics,live-recording,live-streaming -- -D warnings
+cargo clippy --workspace --features cache-memory,cache-redis,hooks,webhooks,statistics,live-recording,live-streaming -- -D warnings
 
 # Check formatting (requires nightly)
 cargo +nightly fmt --all -- --check
 
 # Run all test harnesses (unit + integration + e2e + doctests)
-cargo test --test unit --features "cache-memory,cache-json,hooks,webhooks,statistics,live-recording"
-cargo test --test integration --features "cache-memory,cache-json,hooks,webhooks,statistics,live-recording"
-cargo test --test e2e --features "cache-memory,cache-json,hooks,webhooks,statistics,live-recording" -- --test-threads=1
+cargo test --test unit --features "cache-memory,cache-json,hooks,webhooks,statistics,live-recording,live-streaming"
+cargo test --test integration --features "cache-memory,cache-json,hooks,webhooks,statistics,live-recording,live-streaming"
+cargo test --test e2e --features "cache-memory,cache-json,hooks,webhooks,statistics,live-recording,live-streaming" -- --test-threads=1
 cargo test --doc --workspace
 
 # Check dependencies (licenses, advisories, bans)

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -113,7 +113,7 @@ src/
 │   └── selector.rs     #    VideoQuality, AudioQuality, StoryboardQuality enums
 ├── cache/              # 🔍 VideoCache, DownloadCache, PlaylistCache (feature-gated)
 │   └── backend/        #    Backend trait + implementations (memory/moka, json, redb, redis)
-├── live/               # 🔴 Live stream recording (feature: live-recording)
+├── live/               # 🔴 Live recording/streaming (features: live-recording, live-streaming)
 │   ├── hls.rs          #    HLS manifest parsing via m3u8-rs
 │   ├── recording.rs    #    Reqwest-based HLS segment recorder (primary)
 │   └── ffmpeg_recording.rs  # FFmpeg-based recorder (fallback)
@@ -629,6 +629,7 @@ MyNewEvent(u64, String),
 | `cache-redb` | Embedded redb backend | `redb` |
 | `cache-redis` | Distributed Redis backend | `redis` |
 | `live-recording` | Live stream recording (HLS) | `m3u8-rs` |
+| `live-streaming` | Live fragment streaming (HLS) | `m3u8-rs` |
 | `rustls` | TLS backend | `reqwest/rustls` |
 | `hickory-dns` | Async DNS resolver | `reqwest/hickory-dns` |
 | `profiling` | Heap profiler | `dhat` |
@@ -886,13 +887,13 @@ cargo test --doc --workspace
 
 Before submitting your PR, make sure:
 
-- [ ] 🔍 `cargo clippy --workspace --features cache-memory,cache-json,hooks,webhooks,statistics,live-recording -- -D warnings` — zero warnings
-- [ ] 🔍 `cargo clippy --workspace --features cache-memory,cache-redb,hooks,webhooks,statistics,live-recording -- -D warnings` — zero warnings
-- [ ] 🔍 `cargo clippy --workspace --features cache-memory,cache-redis,hooks,webhooks,statistics,live-recording -- -D warnings` — zero warnings
+- [ ] 🔍 `cargo clippy --workspace --features cache-memory,cache-json,hooks,webhooks,statistics,live-recording,live-streaming -- -D warnings` — zero warnings
+- [ ] 🔍 `cargo clippy --workspace --features cache-memory,cache-redb,hooks,webhooks,statistics,live-recording,live-streaming -- -D warnings` — zero warnings
+- [ ] 🔍 `cargo clippy --workspace --features cache-memory,cache-redis,hooks,webhooks,statistics,live-recording,live-streaming -- -D warnings` — zero warnings
 - [ ] 💄 `cargo +nightly fmt --all -- --check` — properly formatted
-- [ ] 🧪 `cargo test --test unit --features "cache-memory,cache-json,hooks,webhooks,statistics,live-recording"` — all unit tests pass
-- [ ] 🧪 `cargo test --test integration --features "cache-memory,cache-json,hooks,webhooks,statistics,live-recording"` — all integration tests pass
-- [ ] 🧪 `cargo test --test e2e --features "cache-memory,cache-json,hooks,webhooks,statistics,live-recording" -- --test-threads=1` — all E2E tests pass
+- [ ] 🧪 `cargo test --test unit --features "cache-memory,cache-json,hooks,webhooks,statistics,live-recording,live-streaming"` — all unit tests pass
+- [ ] 🧪 `cargo test --test integration --features "cache-memory,cache-json,hooks,webhooks,statistics,live-recording,live-streaming"` — all integration tests pass
+- [ ] 🧪 `cargo test --test e2e --features "cache-memory,cache-json,hooks,webhooks,statistics,live-recording,live-streaming" -- --test-threads=1` — all E2E tests pass
 - [ ] 🧪 `cargo test --doc --workspace` — all doc-tests pass
 - [ ] 🔐 `cargo deny check` — no dependency issues
 - [ ] 🧹 `cargo machete` — no unused dependencies

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,7 +29,7 @@ keywords = ["youtube", "downloader", "async", "yt-dlp", "youtube-dl"]
 debug = true
 
 [package.metadata.docs.rs]
-features = ["cache-memory", "cache-redb", "hooks", "webhooks", "statistics", "profiling"]
+features = ["cache-memory", "cache-redb", "hooks", "webhooks", "statistics", "profiling", "live-recording", "live-streaming"]
 targets = ["x86_64-unknown-linux-gnu", "x86_64-pc-windows-msvc", "aarch64-apple-darwin"]
 
 [package.metadata.release]
@@ -63,6 +63,8 @@ cache-redb = ["dep:redb"]
 # Redis cache backend (distributed/server). Enable with features = ["cache-redis"].
 cache-redis = ["dep:redis"]
 
+# Live fragment streaming via HLS (reqwest). Enable with features = ["live-streaming"].
+live-streaming = ["dep:m3u8-rs"]
 # Live stream recording via HLS (reqwest + ffmpeg fallback). Enable with features = ["live-recording"].
 live-recording = ["dep:m3u8-rs"]
 

--- a/README.md
+++ b/README.md
@@ -2215,7 +2215,38 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
 - **Reqwest engine** (default): Pure-Rust HLS segment fetcher. Polls the media playlist, downloads new segments, and writes them sequentially. Zero-copy `bytes::Bytes`, progress events throttled at 50 ms.
 - **FFmpeg engine** (fallback): Spawns `ffmpeg -i <url> -c copy <output>`. Stops gracefully via stdin `q`. Useful for encrypted streams or complex HLS features.
 - Recording stops on cancellation token, `#EXT-X-ENDLIST`, or max duration.
-- Live events: `LiveRecordingStarted`, `LiveRecordingProgress`, `LiveRecordingStopped`, `LiveRecordingFailed`.
+- Live events: `LiveRecordingStarted`, `LiveRecordingProgress`, `LiveRecordingStopped`, `LiveRecordingFailed`, `LiveStreamStarted`, `LiveStreamStopped`, `LiveStreamFailed`.
+
+#### 📡 Live fragment streaming
+
+```rust,ignore
+use yt_dlp::Downloader;
+use yt_dlp::client::deps::Libraries;
+use std::path::PathBuf;
+use tokio_stream::StreamExt;
+
+#[tokio::main]
+async fn main() -> Result<(), Box<dyn std::error::Error>> {
+    let libraries = Libraries::new(
+        PathBuf::from("libs/yt-dlp"),
+        PathBuf::from("libs/ffmpeg"),
+    );
+    let downloader = Downloader::builder(libraries, "output").build().await?;
+
+    let video = downloader.fetch_video_infos("https://youtube.com/watch?v=LIVE_ID").await?;
+
+    let mut stream = downloader.stream_live(&video)
+        .execute()
+        .await?;
+
+    while let Some(fragment) = stream.next().await {
+        let fragment = fragment?;
+        println!("Fragment {} bytes", fragment.data.len());
+    }
+
+    Ok(())
+}
+```
 
 ### 🎨 Post-Processing Options
 

--- a/README.md
+++ b/README.md
@@ -105,6 +105,7 @@ available.
 - 🗄️ **`cache-redb`** — Embedded [redb](https://github.com/cberner/redb) backend. Single-file, pure-Rust, ACID-compliant.
 - 🌐 **`cache-redis`** — Distributed [Redis](https://redis.io/) backend. Native TTL via `SETEX`.
 - 🔴 **`live-recording`** - Enables live stream recording via HLS segment fetching (reqwest) or FFmpeg fallback. Pulls in `m3u8-rs` for HLS manifest parsing.
+- 📡 **`live-streaming`** - Enables live fragment streaming via HLS segment fetching (reqwest). Pulls in `m3u8-rs` for HLS manifest parsing.
 - 🔒 **`rustls`** - Enables the `rustls-tls` feature in the [```reqwest```](https://crates.io/crates/reqwest) crate.
   This enables building the application without openssl or other system sourced SSL libraries.
 - 🌍 **`hickory-dns`** - Enables async DNS resolution via [Hickory DNS](https://github.com/hickory-dns/hickory-dns) (passes `reqwest/hickory-dns`). Replaces the default blocking system resolver with a fully async, pure-Rust resolver.
@@ -2215,9 +2216,17 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
 - **Reqwest engine** (default): Pure-Rust HLS segment fetcher. Polls the media playlist, downloads new segments, and writes them sequentially. Zero-copy `bytes::Bytes`, progress events throttled at 50 ms.
 - **FFmpeg engine** (fallback): Spawns `ffmpeg -i <url> -c copy <output>`. Stops gracefully via stdin `q`. Useful for encrypted streams or complex HLS features.
 - Recording stops on cancellation token, `#EXT-X-ENDLIST`, or max duration.
-- Live events: `LiveRecordingStarted`, `LiveRecordingProgress`, `LiveRecordingStopped`, `LiveRecordingFailed`, `LiveStreamStarted`, `LiveStreamStopped`, `LiveStreamFailed`.
+- Recording events: `LiveRecordingStarted`, `LiveRecordingProgress`, `LiveRecordingStopped`, `LiveRecordingFailed`.
+- Streaming events: `LiveStreamStarted`, `LiveStreamProgress`, `LiveStreamStopped`, `LiveStreamFailed`.
 
-#### 📡 Live fragment streaming
+#### 📡 Live fragment streaming (Feature: `live-streaming`)
+
+Enable the feature in your `Cargo.toml`:
+
+```toml
+[dependencies]
+yt-dlp = { version = "2.4.0", features = ["live-streaming"] }
+```
 
 ```rust,ignore
 use yt_dlp::Downloader;

--- a/src/error.rs
+++ b/src/error.rs
@@ -207,7 +207,7 @@ pub enum Error {
 
     // ==================== Live Stream Errors ====================
     /// The video is not currently a live stream.
-    #[cfg(feature = "live-recording")]
+    #[cfg(any(feature = "live-recording", feature = "live-streaming"))]
     #[error("Video at {url} is not live (status={live_status}): {reason}")]
     LiveStreamUnavailable {
         url: String,
@@ -216,7 +216,7 @@ pub enum Error {
     },
 
     /// Failed to parse an HLS manifest.
-    #[cfg(feature = "live-recording")]
+    #[cfg(any(feature = "live-recording", feature = "live-streaming"))]
     #[error("HLS parsing failed for {url}: {context}")]
     HlsParsing { url: String, context: String },
 
@@ -224,6 +224,11 @@ pub enum Error {
     #[cfg(feature = "live-recording")]
     #[error("Live recording failed for {url}: {reason}")]
     LiveRecording { url: String, reason: String },
+
+    /// A live streaming operation failed.
+    #[cfg(feature = "live-streaming")]
+    #[error("Live streaming failed for {url}: {reason}")]
+    LiveStreaming { url: String, reason: String },
 
     // ==================== Metadata Errors ====================
     /// A metadata tagging operation failed.
@@ -596,7 +601,7 @@ impl Error {
     /// # Returns
     ///
     /// An Error::LiveStreamUnavailable variant with the provided details
-    #[cfg(feature = "live-recording")]
+    #[cfg(any(feature = "live-recording", feature = "live-streaming"))]
     pub fn live_unavailable(url: impl Into<String>, live_status: impl Into<String>, reason: impl Into<String>) -> Self {
         let url_str = url.into();
         let live_status_str = live_status.into();
@@ -626,7 +631,7 @@ impl Error {
     /// # Returns
     ///
     /// An Error::HlsParsing variant with the provided details
-    #[cfg(feature = "live-recording")]
+    #[cfg(any(feature = "live-recording", feature = "live-streaming"))]
     pub fn hls_parsing(url: impl Into<String>, context: impl Into<String>) -> Self {
         let url_str = url.into();
         let context_str = context.into();
@@ -660,6 +665,45 @@ impl Error {
             url: url_str,
             reason: reason_str,
         }
+    }
+
+    /// Create a live streaming error.
+    ///
+    /// # Arguments
+    ///
+    /// * `url` - The URL of the live stream
+    /// * `reason` - Why the streaming failed
+    ///
+    /// # Returns
+    ///
+    /// An Error::LiveStreaming variant with the provided details
+    #[cfg(feature = "live-streaming")]
+    pub fn live_streaming(url: impl Into<String>, reason: impl Into<String>) -> Self {
+        let url_str = url.into();
+        let reason_str = reason.into();
+
+        tracing::error!(url = url_str, reason = reason_str, "Live streaming failed");
+
+        Self::LiveStreaming {
+            url: url_str,
+            reason: reason_str,
+        }
+    }
+
+    /// Create an error for a failed live segment fetch.
+    ///
+    /// # Arguments
+    ///
+    /// * `url` - The URL of the live segment
+    /// * `status` - The HTTP status code returned
+    ///
+    /// # Returns
+    ///
+    /// An Error::LiveStreaming variant with the provided details
+    #[cfg(feature = "live-streaming")]
+    pub fn live_segment_fetch_failed(url: &str, status: reqwest::StatusCode) -> Self {
+        let reason = format!("{} {}", SEGMENT_FETCH_ERROR_PREFIX, status);
+        Self::live_streaming(url, reason)
     }
 
     /// Create a metadata error with operation and path context.
@@ -850,3 +894,6 @@ impl From<zip::result::ZipError> for Error {
         }
     }
 }
+/// Error context prefix for failed segment fetches.
+#[cfg(feature = "live-streaming")]
+const SEGMENT_FETCH_ERROR_PREFIX: &str = "segment fetch returned HTTP";

--- a/src/events/filters.rs
+++ b/src/events/filters.rs
@@ -202,16 +202,6 @@ impl EventFilter {
         ])
     }
 
-    /// Deprecated alias for [`EventFilter::only_live_recording`].
-    ///
-    /// This method has been renamed to [`only_live_recording`]. It is kept for
-    /// backwards compatibility and may be removed in a future major release.
-    #[deprecated(note = "renamed to `only_live_recording`; use that instead")]
-    #[cfg(feature = "live-recording")]
-    pub fn only_live() -> Self {
-        Self::only_live_recording()
-    }
-
     /// Creates a filter for live recording events matching a specific video ID.
     #[cfg(feature = "live-recording")]
     pub fn live_recording(video_id: impl Into<String>) -> Self {

--- a/src/events/filters.rs
+++ b/src/events/filters.rs
@@ -191,9 +191,9 @@ impl EventFilter {
         Self::any_of(&["post_process_started", "post_process_completed", "post_process_failed"])
     }
 
-    /// Creates a filter for live recording events
+    /// Creates a filter for live recording events.
     #[cfg(feature = "live-recording")]
-    pub fn only_live() -> Self {
+    pub fn only_live_recording() -> Self {
         Self::any_of(&[
             "live_recording_started",
             "live_recording_progress",
@@ -202,17 +202,28 @@ impl EventFilter {
         ])
     }
 
-    /// Creates a filter for live recording events matching a specific video ID
+    /// Creates a filter for live recording events matching a specific video ID.
     #[cfg(feature = "live-recording")]
     pub fn live_recording(video_id: impl Into<String>) -> Self {
         let id = video_id.into();
-        Self::only_live().and_then(move |event| match event {
+        Self::only_live_recording().and_then(move |event| match event {
             DownloadEvent::LiveRecordingStarted { video_id, .. }
             | DownloadEvent::LiveRecordingProgress { video_id, .. }
             | DownloadEvent::LiveRecordingStopped { video_id, .. }
             | DownloadEvent::LiveRecordingFailed { video_id, .. } => video_id == &id,
             _ => false,
         })
+    }
+
+    /// Creates a filter for live streaming events.
+    #[cfg(feature = "live-streaming")]
+    pub fn only_live_streaming() -> Self {
+        Self::any_of(&[
+            "live_stream_started",
+            "live_stream_progress",
+            "live_stream_stopped",
+            "live_stream_failed",
+        ])
     }
 }
 

--- a/src/events/filters.rs
+++ b/src/events/filters.rs
@@ -202,6 +202,16 @@ impl EventFilter {
         ])
     }
 
+    /// Deprecated alias for [`EventFilter::only_live_recording`].
+    ///
+    /// This method has been renamed to [`only_live_recording`]. It is kept for
+    /// backwards compatibility and may be removed in a future major release.
+    #[deprecated(note = "renamed to `only_live_recording`; use that instead")]
+    #[cfg(feature = "live-recording")]
+    pub fn only_live() -> Self {
+        Self::only_live_recording()
+    }
+
     /// Creates a filter for live recording events matching a specific video ID.
     #[cfg(feature = "live-recording")]
     pub fn live_recording(video_id: impl Into<String>) -> Self {

--- a/src/events/types.rs
+++ b/src/events/types.rs
@@ -204,6 +204,20 @@ pub enum DownloadEvent {
         bitrate_bps: f64,
     },
 
+    /// Live recording stopped (graceful)
+    #[cfg(feature = "live-recording")]
+    LiveRecordingStopped {
+        video_id: String,
+        reason: String,
+        output_path: PathBuf,
+        total_bytes: u64,
+        total_duration: Duration,
+    },
+
+    /// Live recording failed
+    #[cfg(feature = "live-recording")]
+    LiveRecordingFailed { video_id: String, error: String },
+
     /// Live fragment streaming started
     #[cfg(feature = "live-streaming")]
     LiveStreamStarted {
@@ -234,20 +248,6 @@ pub enum DownloadEvent {
     /// Live fragment streaming failed
     #[cfg(feature = "live-streaming")]
     LiveStreamFailed { video_id: String, error: String },
-
-    /// Live recording stopped (graceful)
-    #[cfg(feature = "live-recording")]
-    LiveRecordingStopped {
-        video_id: String,
-        reason: String,
-        output_path: PathBuf,
-        total_bytes: u64,
-        total_duration: Duration,
-    },
-
-    /// Live recording failed
-    #[cfg(feature = "live-recording")]
-    LiveRecordingFailed { video_id: String, error: String },
 }
 
 /// Types of metadata that can be applied

--- a/src/events/types.rs
+++ b/src/events/types.rs
@@ -8,7 +8,7 @@ use crate::model::chapter::Chapter;
 use crate::model::format::Format;
 use crate::model::playlist::Playlist;
 
-/// The method used for live recording
+/// The method used for live recording.
 #[cfg(feature = "live-recording")]
 #[derive(Debug, Clone, PartialEq, Eq, serde::Serialize)]
 pub enum RecordingMethod {
@@ -205,7 +205,7 @@ pub enum DownloadEvent {
     },
 
     /// Live fragment streaming started
-    #[cfg(feature = "live-recording")]
+    #[cfg(feature = "live-streaming")]
     LiveStreamStarted {
         video_id: String,
         url: String,
@@ -213,7 +213,7 @@ pub enum DownloadEvent {
     },
 
     /// Live fragment streaming progress update
-    #[cfg(feature = "live-recording")]
+    #[cfg(feature = "live-streaming")]
     LiveStreamProgress {
         video_id: String,
         elapsed: Duration,
@@ -223,7 +223,7 @@ pub enum DownloadEvent {
     },
 
     /// Live fragment streaming stopped
-    #[cfg(feature = "live-recording")]
+    #[cfg(feature = "live-streaming")]
     LiveStreamStopped {
         video_id: String,
         reason: String,
@@ -232,7 +232,7 @@ pub enum DownloadEvent {
     },
 
     /// Live fragment streaming failed
-    #[cfg(feature = "live-recording")]
+    #[cfg(feature = "live-streaming")]
     LiveStreamFailed { video_id: String, error: String },
 
     /// Live recording stopped (graceful)
@@ -341,10 +341,14 @@ impl DownloadEvent {
 
     /// Returns true if this is a progress event
     pub fn is_progress(&self) -> bool {
-        matches!(
-            self,
-            Self::DownloadProgress { .. } | Self::LiveStreamProgress { .. } | Self::LiveRecordingProgress { .. }
-        )
+        match self {
+            Self::DownloadProgress { .. } => true,
+            #[cfg(feature = "live-recording")]
+            Self::LiveRecordingProgress { .. } => true,
+            #[cfg(feature = "live-streaming")]
+            Self::LiveStreamProgress { .. } => true,
+            _ => false,
+        }
     }
 
     /// Returns a human-readable event type name
@@ -382,13 +386,13 @@ impl DownloadEvent {
             Self::LiveRecordingStopped { .. } => "live_recording_stopped",
             #[cfg(feature = "live-recording")]
             Self::LiveRecordingFailed { .. } => "live_recording_failed",
-            #[cfg(feature = "live-recording")]
+            #[cfg(feature = "live-streaming")]
             Self::LiveStreamStarted { .. } => "live_stream_started",
-            #[cfg(feature = "live-recording")]
+            #[cfg(feature = "live-streaming")]
             Self::LiveStreamProgress { .. } => "live_stream_progress",
-            #[cfg(feature = "live-recording")]
+            #[cfg(feature = "live-streaming")]
             Self::LiveStreamStopped { .. } => "live_stream_stopped",
-            #[cfg(feature = "live-recording")]
+            #[cfg(feature = "live-streaming")]
             Self::LiveStreamFailed { .. } => "live_stream_failed",
         }
     }

--- a/src/events/types.rs
+++ b/src/events/types.rs
@@ -204,6 +204,37 @@ pub enum DownloadEvent {
         bitrate_bps: f64,
     },
 
+    /// Live fragment streaming started
+    #[cfg(feature = "live-recording")]
+    LiveStreamStarted {
+        video_id: String,
+        url: String,
+        quality: String,
+    },
+
+    /// Live fragment streaming progress update
+    #[cfg(feature = "live-recording")]
+    LiveStreamProgress {
+        video_id: String,
+        elapsed: Duration,
+        bytes_received: u64,
+        segments: u64,
+        bitrate_bps: f64,
+    },
+
+    /// Live fragment streaming stopped
+    #[cfg(feature = "live-recording")]
+    LiveStreamStopped {
+        video_id: String,
+        reason: String,
+        total_bytes: u64,
+        total_duration: Duration,
+    },
+
+    /// Live fragment streaming failed
+    #[cfg(feature = "live-recording")]
+    LiveStreamFailed { video_id: String, error: String },
+
     /// Live recording stopped (graceful)
     #[cfg(feature = "live-recording")]
     LiveRecordingStopped {
@@ -310,7 +341,10 @@ impl DownloadEvent {
 
     /// Returns true if this is a progress event
     pub fn is_progress(&self) -> bool {
-        matches!(self, Self::DownloadProgress { .. })
+        matches!(
+            self,
+            Self::DownloadProgress { .. } | Self::LiveStreamProgress { .. } | Self::LiveRecordingProgress { .. }
+        )
     }
 
     /// Returns a human-readable event type name
@@ -348,6 +382,14 @@ impl DownloadEvent {
             Self::LiveRecordingStopped { .. } => "live_recording_stopped",
             #[cfg(feature = "live-recording")]
             Self::LiveRecordingFailed { .. } => "live_recording_failed",
+            #[cfg(feature = "live-recording")]
+            Self::LiveStreamStarted { .. } => "live_stream_started",
+            #[cfg(feature = "live-recording")]
+            Self::LiveStreamProgress { .. } => "live_stream_progress",
+            #[cfg(feature = "live-recording")]
+            Self::LiveStreamStopped { .. } => "live_stream_stopped",
+            #[cfg(feature = "live-recording")]
+            Self::LiveStreamFailed { .. } => "live_stream_failed",
         }
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -43,8 +43,8 @@ pub use async_trait;
 #[cfg(feature = "statistics")]
 pub mod stats;
 
-// Live stream recording
-#[cfg(feature = "live-recording")]
+// Live stream recording and streaming
+#[cfg(any(feature = "live-recording", feature = "live-streaming"))]
 pub mod live;
 
 // Convenience modules
@@ -336,6 +336,10 @@ impl Downloader {
     ///
     /// * `video` - The live stream video metadata.
     ///
+    /// # Returns
+    ///
+    /// A [`live::LiveStreamBuilder`] configured for the provided live video.
+    ///
     /// # Examples
     ///
     /// ```rust,no_run
@@ -360,7 +364,7 @@ impl Downloader {
     /// # Ok(())
     /// # }
     /// ```
-    #[cfg(feature = "live-recording")]
+    #[cfg(feature = "live-streaming")]
     pub fn stream_live<'a>(&'a self, video: &'a Video) -> live::LiveStreamBuilder<'a> {
         live::LiveStreamBuilder::new(self, video)
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -302,7 +302,6 @@ impl Downloader {
     ///
     /// * `video` - The live stream video metadata.
     /// * `output` - The output filename for the recording.
-    ///
     /// # Examples
     ///
     /// ```rust,no_run
@@ -326,6 +325,44 @@ impl Downloader {
     #[cfg(feature = "live-recording")]
     pub fn record_live<'a>(&'a self, video: &'a Video, output: impl Into<PathBuf>) -> live::LiveRecordingBuilder<'a> {
         live::LiveRecordingBuilder::new(self, video, output)
+    }
+
+    /// Creates a live stream builder for streaming HLS fragments.
+    ///
+    /// The video must be currently live (`is_currently_live() == true`).
+    /// Only the reqwest engine is supported for fragment streaming.
+    ///
+    /// # Arguments
+    ///
+    /// * `video` - The live stream video metadata.
+    ///
+    /// # Examples
+    ///
+    /// ```rust,no_run
+    /// # use yt_dlp::Downloader;
+    /// # use yt_dlp::client::deps::Libraries;
+    /// # use std::path::PathBuf;
+    /// # use tokio_stream::StreamExt;
+    /// # #[tokio::main]
+    /// # async fn main() -> Result<(), Box<dyn std::error::Error>> {
+    /// # let libraries = Libraries::new(PathBuf::from("libs/yt-dlp"), PathBuf::from("libs/ffmpeg"));
+    /// # let downloader = Downloader::builder(libraries, "output").build().await?;
+    /// let video = downloader.fetch_video_infos("https://youtube.com/watch?v=LIVE_ID").await?;
+    ///
+    /// let mut stream = downloader.stream_live(&video)
+    ///     .execute()
+    ///     .await?;
+    ///
+    /// while let Some(fragment) = stream.next().await {
+    ///     let fragment = fragment?;
+    ///     println!("Fragment {} bytes", fragment.data.len());
+    /// }
+    /// # Ok(())
+    /// # }
+    /// ```
+    #[cfg(feature = "live-recording")]
+    pub fn stream_live<'a>(&'a self, video: &'a Video) -> live::LiveStreamBuilder<'a> {
+        live::LiveStreamBuilder::new(self, video)
     }
 
     /// Creates a new YouTube fetcher, and installs the yt-dlp and ffmpeg binaries.

--- a/src/live/core.rs
+++ b/src/live/core.rs
@@ -55,6 +55,26 @@ pub struct LiveFragment {
     pub data: Vec<u8>,
 }
 
+/// Configuration required to construct a [`LiveCore`] instance.
+pub(super) struct LiveCoreConfig {
+    /// The URL of the HLS media playlist to poll.
+    pub(super) playlist_url: String,
+    /// The video ID (for event emission).
+    pub(super) video_id: String,
+    /// Quality label for event metadata.
+    pub(super) quality: String,
+    /// Optional maximum recording duration.
+    pub(super) max_duration: Option<Duration>,
+    /// Cancellation token for graceful stop.
+    pub(super) cancellation_token: CancellationToken,
+    /// Shared HTTP client.
+    pub(super) client: Arc<reqwest::Client>,
+    /// The event bus for emitting recording events.
+    pub(super) event_bus: EventBus,
+    /// Optional output path for recording mode.
+    pub(super) output_path: Option<PathBuf>,
+}
+
 /// Shared state and utilities for live recording/streaming.
 #[derive(Debug, Clone)]
 pub(super) struct LiveCore {
@@ -78,26 +98,21 @@ pub(super) struct LiveCore {
 }
 
 impl LiveCore {
-    #[allow(clippy::too_many_arguments)]
-    pub(super) fn new(
-        playlist_url: String,
-        video_id: String,
-        quality: String,
-        max_duration: Option<Duration>,
-        cancellation_token: CancellationToken,
-        client: Arc<reqwest::Client>,
-        event_bus: EventBus,
-        output_path: Option<PathBuf>,
-    ) -> Self {
+    /// Creates a new [`LiveCore`] from the provided configuration.
+    ///
+    /// # Arguments
+    ///
+    /// * `config` - All shared state needed by the live recording/streaming engines.
+    pub(super) fn new(config: LiveCoreConfig) -> Self {
         Self {
-            playlist_url,
-            video_id,
-            quality,
-            max_duration,
-            cancellation_token,
-            client,
-            event_bus,
-            output_path,
+            playlist_url: config.playlist_url,
+            video_id: config.video_id,
+            quality: config.quality,
+            max_duration: config.max_duration,
+            cancellation_token: config.cancellation_token,
+            client: config.client,
+            event_bus: config.event_bus,
+            output_path: config.output_path,
         }
     }
 

--- a/src/live/core.rs
+++ b/src/live/core.rs
@@ -1,0 +1,190 @@
+use std::path::PathBuf;
+use std::sync::Arc;
+use std::time::Duration;
+
+use tokio::time;
+use tokio_util::sync::CancellationToken;
+
+use super::hls;
+use crate::error::{Error, Result};
+use crate::events::EventBus;
+
+/// Progress throttle interval (50 ms) to avoid flooding the event bus.
+pub(super) const PROGRESS_THROTTLE_NANOS: u64 = 50_000_000;
+
+/// Maximum number of retry attempts per segment fetch.
+pub(super) const SEGMENT_RETRY_ATTEMPTS: u32 = 3;
+
+/// Delay between segment fetch retries.
+pub(super) const SEGMENT_RETRY_DELAY: Duration = Duration::from_millis(500);
+
+/// Divisor applied to target duration to derive poll interval.
+pub(super) const POLL_INTERVAL_DIVISOR: f64 = 2.0;
+
+/// Bitrate conversion multiplier for bytes to bits.
+pub(super) const BITS_PER_BYTE: f64 = 8.0;
+
+/// Zero value for u64 counters.
+pub(super) const ZERO_U64: u64 = 0;
+
+/// Zero value for f64 calculations.
+pub(super) const ZERO_F64: f64 = 0.0;
+
+/// Determines which error variant to use for segment fetch failures.
+#[derive(Debug, Clone, Copy)]
+pub(super) enum SegmentErrorMode {
+    #[cfg(feature = "live-recording")]
+    Recording,
+    #[cfg(feature = "live-streaming")]
+    Streaming,
+}
+
+/// A single live fragment downloaded from an HLS stream.
+#[derive(Debug, Clone)]
+pub struct LiveFragment {
+    /// The segment sequence number.
+    #[allow(dead_code)]
+    pub sequence: u64,
+    /// The segment duration.
+    #[allow(dead_code)]
+    pub duration: Duration,
+    /// The absolute URL for the fragment.
+    #[allow(dead_code)]
+    pub url: String,
+    /// The fragment bytes.
+    pub data: Vec<u8>,
+}
+
+/// Shared state and utilities for live recording/streaming.
+#[derive(Debug, Clone)]
+pub(super) struct LiveCore {
+    /// The URL of the HLS media playlist to poll.
+    pub(super) playlist_url: String,
+    /// The video ID (for event emission).
+    pub(super) video_id: String,
+    /// Quality label for event metadata.
+    pub(super) quality: String,
+    /// Optional maximum recording duration.
+    pub(super) max_duration: Option<Duration>,
+    /// Cancellation token for graceful stop.
+    pub(super) cancellation_token: CancellationToken,
+    /// Shared HTTP client.
+    pub(super) client: Arc<reqwest::Client>,
+    /// The event bus for emitting recording events.
+    pub(super) event_bus: EventBus,
+    /// Optional output path for recording mode.
+    #[allow(dead_code)]
+    pub(super) output_path: Option<PathBuf>,
+}
+
+impl LiveCore {
+    #[allow(clippy::too_many_arguments)]
+    pub(super) fn new(
+        playlist_url: String,
+        video_id: String,
+        quality: String,
+        max_duration: Option<Duration>,
+        cancellation_token: CancellationToken,
+        client: Arc<reqwest::Client>,
+        event_bus: EventBus,
+        output_path: Option<PathBuf>,
+    ) -> Self {
+        Self {
+            playlist_url,
+            video_id,
+            quality,
+            max_duration,
+            cancellation_token,
+            client,
+            event_bus,
+            output_path,
+        }
+    }
+
+    /// Fetches a single segment's bytes with retries.
+    pub(super) async fn fetch_segment(&self, url: &str, mode: SegmentErrorMode) -> Result<Vec<u8>> {
+        let mut last_error = None;
+
+        for attempt in 1..=SEGMENT_RETRY_ATTEMPTS {
+            match self.fetch_segment_once(url, mode).await {
+                Ok(data) => return Ok(data),
+                Err(e) => {
+                    if attempt < SEGMENT_RETRY_ATTEMPTS {
+                        tracing::warn!(
+                            url = url,
+                            attempt = attempt,
+                            max_attempts = SEGMENT_RETRY_ATTEMPTS,
+                            error = %e,
+                            "Segment fetch failed, retrying"
+                        );
+                        time::sleep(SEGMENT_RETRY_DELAY).await;
+                    }
+                    last_error = Some(e);
+                }
+            }
+        }
+
+        Err(last_error.unwrap())
+    }
+
+    /// Single attempt to fetch a segment.
+    pub(super) async fn fetch_segment_once(&self, url: &str, mode: SegmentErrorMode) -> Result<Vec<u8>> {
+        let response = self
+            .client
+            .get(url)
+            .send()
+            .await
+            .map_err(|e| Error::http(url, "fetching HLS segment", e))?;
+
+        let status = response.status();
+        if !status.is_success() {
+            return Err(self.segment_fetch_failed(url, status, mode));
+        }
+
+        let bytes = response
+            .bytes()
+            .await
+            .map_err(|e| Error::http(url, "reading segment body", e))?;
+
+        Ok(bytes.to_vec())
+    }
+
+    /// Fetches a fragment and returns a structured fragment payload.
+    pub(super) async fn fetch_fragment(
+        &self,
+        segment: &hls::HlsSegment,
+        mode: SegmentErrorMode,
+    ) -> Result<LiveFragment> {
+        let data = self.fetch_segment(&segment.url, mode).await?;
+        Ok(LiveFragment {
+            sequence: segment.sequence,
+            duration: Duration::from_secs_f64(segment.duration),
+            url: segment.url.clone(),
+            data,
+        })
+    }
+
+    fn segment_fetch_failed(&self, url: &str, status: reqwest::StatusCode, mode: SegmentErrorMode) -> Error {
+        match mode {
+            #[cfg(feature = "live-recording")]
+            SegmentErrorMode::Recording => {
+                Error::live_recording(url, format!("segment fetch returned HTTP {}", status))
+            }
+            #[cfg(feature = "live-streaming")]
+            SegmentErrorMode::Streaming => Error::live_segment_fetch_failed(url, status),
+        }
+    }
+}
+
+/// Result metrics produced by the recording/streaming loops.
+#[derive(Debug, Clone)]
+pub(super) struct RecordingStats {
+    #[allow(dead_code)]
+    pub(super) total_bytes: u64,
+    #[allow(dead_code)]
+    pub(super) total_duration: Duration,
+    #[allow(dead_code)]
+    pub(super) segments_downloaded: u64,
+    #[allow(dead_code)]
+    pub(super) stop_reason: String,
+}

--- a/src/live/mod.rs
+++ b/src/live/mod.rs
@@ -42,7 +42,7 @@ use crate::error::{Error, Result};
 #[cfg(feature = "live-recording")]
 use crate::events::types::RecordingMethod;
 use crate::model::Video;
-use crate::model::format::Format;
+use crate::model::format::{Format, Protocol};
 
 /// Common configuration shared across live recording engines.
 #[cfg(feature = "live-recording")]
@@ -65,7 +65,7 @@ pub struct RecordingConfig {
 
 /// Common configuration shared across live fragment streaming.
 #[cfg(feature = "live-streaming")]
-pub struct StreamRecordingConfig {
+pub struct LiveStreamConfig {
     /// The HLS stream URL to stream live fragments from.
     pub stream_url: String,
     /// The video ID (for event emission).
@@ -381,7 +381,7 @@ impl<'a> LiveStreamBuilder<'a> {
                 .map_err(|e| Error::http(&resolved.stream_url, "building HTTP client", e))?,
         );
 
-        let config = StreamRecordingConfig {
+        let config = LiveStreamConfig {
             stream_url: resolved.stream_url,
             video_id: self.video.id.clone(),
             quality: resolved.quality,
@@ -423,7 +423,12 @@ fn resolve_live_format(video: &Video, format: Option<&Format>, mode: LiveMode) -
 
     let live_formats = video.live_formats();
     let format = match format {
-        Some(f) => f,
+        Some(f) => {
+            if f.protocol != Protocol::M3U8Native {
+                return Err(live_format_error(video, mode, "format is not an HLS manifest"));
+            }
+            f
+        }
         None => live_formats
             .last()
             .ok_or_else(|| live_format_error(video, mode, "no HLS formats available"))?,

--- a/src/live/mod.rs
+++ b/src/live/mod.rs
@@ -19,7 +19,7 @@ use std::time::Duration;
 
 pub use ffmpeg_recording::FfmpegLiveRecorder;
 pub use hls::{HlsPlaylist, HlsSegment, HlsVariant};
-pub use recording::LiveRecorder;
+pub use recording::{LiveFragment, LiveFragmentStream, LiveFragmentStreamer, LiveRecorder};
 use tokio_util::sync::CancellationToken;
 
 use crate::Downloader;
@@ -34,6 +34,22 @@ pub struct RecordingConfig {
     pub stream_url: String,
     /// The output file path.
     pub output_path: PathBuf,
+    /// The video ID (for event emission).
+    pub video_id: String,
+    /// Quality label (e.g. "1080p").
+    pub quality: String,
+    /// Optional maximum recording duration.
+    pub max_duration: Option<Duration>,
+    /// Cancellation token for graceful stop.
+    pub cancellation_token: CancellationToken,
+    /// The event bus for emitting recording events.
+    pub event_bus: crate::events::EventBus,
+}
+
+/// Common configuration shared across live fragment streaming.
+pub struct StreamRecordingConfig {
+    /// The HLS stream URL to record.
+    pub stream_url: String,
     /// The video ID (for event emission).
     pub video_id: String,
     /// Quality label (e.g. "1080p").
@@ -173,7 +189,7 @@ impl<'a> LiveRecordingBuilder<'a> {
         self
     }
 
-    /// Starts the live recording.
+    /// Starts a live recording and writes it to a file.
     ///
     /// # Errors
     ///
@@ -184,34 +200,7 @@ impl<'a> LiveRecordingBuilder<'a> {
     ///
     /// A [`RecordingResult`] containing recording statistics.
     pub async fn execute(self) -> Result<RecordingResult> {
-        // Validate the video is live
-        if !self.video.is_currently_live() {
-            return Err(Error::live_unavailable(
-                self.video.webpage_url.as_deref().unwrap_or("unknown"),
-                &self.video.live_status,
-                "video is not currently live",
-            ));
-        }
-
-        // Select the format to record
-        let live_formats = self.video.live_formats();
-        let format = match self.format {
-            Some(f) => f,
-            None => live_formats.last().ok_or_else(|| {
-                Error::live_recording(
-                    self.video.webpage_url.as_deref().unwrap_or("unknown"),
-                    "no HLS formats available",
-                )
-            })?,
-        };
-
-        let stream_url = format.url()?.clone();
-        let quality = format
-            .video_resolution
-            .height
-            .map(|h| format!("{h}p"))
-            .unwrap_or_else(|| "unknown".to_string());
-
+        let resolved = resolve_live_format(self.video, self.format)?;
         let cancellation_token = self
             .cancellation_token
             .unwrap_or_else(|| self.downloader.cancellation_token.child_token());
@@ -219,7 +208,7 @@ impl<'a> LiveRecordingBuilder<'a> {
         tracing::info!(
             video_id = self.video.id,
             method = ?self.method,
-            quality = quality,
+            quality = resolved.quality,
             output = ?self.output_path,
             "📥 Starting live recording"
         );
@@ -230,14 +219,14 @@ impl<'a> LiveRecordingBuilder<'a> {
                     reqwest::Client::builder()
                         .tcp_nodelay(true)
                         .build()
-                        .map_err(|e| Error::http(&stream_url, "building HTTP client", e))?,
+                        .map_err(|e| Error::http(&resolved.stream_url, "building HTTP client", e))?,
                 );
 
                 let config = RecordingConfig {
-                    stream_url,
+                    stream_url: resolved.stream_url,
                     output_path: self.output_path,
                     video_id: self.video.id.clone(),
-                    quality,
+                    quality: resolved.quality,
                     max_duration: self.max_duration,
                     cancellation_token,
                     event_bus: self.downloader.event_bus.clone(),
@@ -248,10 +237,10 @@ impl<'a> LiveRecordingBuilder<'a> {
             }
             RecordingMethod::Fallback => {
                 let config = RecordingConfig {
-                    stream_url,
+                    stream_url: resolved.stream_url,
                     output_path: self.output_path,
                     video_id: self.video.id.clone(),
-                    quality,
+                    quality: resolved.quality,
                     max_duration: self.max_duration,
                     cancellation_token,
                     event_bus: self.downloader.event_bus.clone(),
@@ -262,6 +251,159 @@ impl<'a> LiveRecordingBuilder<'a> {
             }
         }
     }
+}
+
+/// Fluent builder for configuring and starting a live fragment stream.
+///
+/// Created via [`Downloader::stream_live`]. Allows configuring format selection,
+/// maximum duration, and cancellation token before starting.
+pub struct LiveStreamBuilder<'a> {
+    downloader: &'a Downloader,
+    video: &'a Video,
+    max_duration: Option<Duration>,
+    format: Option<&'a Format>,
+    cancellation_token: Option<CancellationToken>,
+}
+
+impl fmt::Debug for LiveStreamBuilder<'_> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("LiveStreamBuilder")
+            .field("video_id", &self.video.id)
+            .field("max_duration", &self.max_duration)
+            .field("has_format", &self.format.is_some())
+            .field("has_token", &self.cancellation_token.is_some())
+            .finish()
+    }
+}
+
+impl<'a> LiveStreamBuilder<'a> {
+    /// Creates a new live stream builder.
+    ///
+    /// # Arguments
+    ///
+    /// * `downloader` - Reference to the downloader.
+    /// * `video` - The video metadata (must be a live stream).
+    pub(crate) fn new(downloader: &'a Downloader, video: &'a Video) -> Self {
+        Self {
+            downloader,
+            video,
+            max_duration: None,
+            format: None,
+            cancellation_token: None,
+        }
+    }
+
+    /// Sets the maximum streaming duration.
+    ///
+    /// # Arguments
+    ///
+    /// * `duration` - Maximum time to stream before automatically stopping.
+    pub fn with_max_duration(mut self, duration: Duration) -> Self {
+        self.max_duration = Some(duration);
+        self
+    }
+
+    /// Selects a specific HLS format for streaming.
+    ///
+    /// If not set, the best quality live format is automatically selected.
+    ///
+    /// # Arguments
+    ///
+    /// * `format` - The HLS format to stream.
+    pub fn with_format(mut self, format: &'a Format) -> Self {
+        self.format = Some(format);
+        self
+    }
+
+    /// Sets a custom cancellation token.
+    ///
+    /// If not set, the downloader's cancellation token is used.
+    ///
+    /// # Arguments
+    ///
+    /// * `token` - The cancellation token to control streaming lifecycle.
+    pub fn with_cancellation_token(mut self, token: CancellationToken) -> Self {
+        self.cancellation_token = Some(token);
+        self
+    }
+
+    /// Starts streaming live fragments.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if the video is not a live stream, no HLS format is available,
+    /// or the streaming engine encounters an error.
+    ///
+    /// # Returns
+    ///
+    /// A [`LiveFragmentStream`] that yields HLS fragments as they are downloaded.
+    pub async fn execute(self) -> Result<LiveFragmentStream> {
+        let resolved = resolve_live_format(self.video, self.format)?;
+        let cancellation_token = self
+            .cancellation_token
+            .unwrap_or_else(|| self.downloader.cancellation_token.child_token());
+
+        tracing::info!(
+            video_id = self.video.id,
+            quality = resolved.quality,
+            "📥 Starting live fragment stream"
+        );
+
+        let client = Arc::new(
+            reqwest::Client::builder()
+                .tcp_nodelay(true)
+                .build()
+                .map_err(|e| Error::http(&resolved.stream_url, "building HTTP client", e))?,
+        );
+
+        let config = StreamRecordingConfig {
+            stream_url: resolved.stream_url,
+            video_id: self.video.id.clone(),
+            quality: resolved.quality,
+            max_duration: self.max_duration,
+            cancellation_token,
+            event_bus: self.downloader.event_bus.clone(),
+        };
+
+        let streamer = LiveFragmentStreamer::new(config, client);
+        streamer.stream().await
+    }
+}
+
+#[derive(Debug, Clone)]
+struct ResolvedLiveFormat {
+    stream_url: String,
+    quality: String,
+}
+
+fn resolve_live_format(video: &Video, format: Option<&Format>) -> Result<ResolvedLiveFormat> {
+    if !video.is_currently_live() {
+        return Err(Error::live_unavailable(
+            video.webpage_url.as_deref().unwrap_or("unknown"),
+            &video.live_status,
+            "video is not currently live",
+        ));
+    }
+
+    let live_formats = video.live_formats();
+    let format = match format {
+        Some(f) => f,
+        None => live_formats.last().ok_or_else(|| {
+            Error::live_recording(
+                video.webpage_url.as_deref().unwrap_or("unknown"),
+                "no HLS formats available",
+            )
+        })?,
+    };
+
+    let stream_url = format.url()?.clone();
+    let quality = format
+        .video_resolution
+        .height
+        .map(|h| format!("{h}p"))
+        .unwrap_or_else(|| "unknown".to_string());
+
+    Ok(ResolvedLiveFormat { stream_url, quality })
 }
 
 impl fmt::Debug for LiveRecordingBuilder<'_> {

--- a/src/live/mod.rs
+++ b/src/live/mod.rs
@@ -11,11 +11,9 @@
 #[cfg(any(feature = "live-recording", feature = "live-streaming"))]
 mod core;
 #[cfg(feature = "live-recording")]
-pub mod ffmpeg_recording;
+pub mod recording;
 #[cfg(any(feature = "live-recording", feature = "live-streaming"))]
 pub mod hls;
-#[cfg(feature = "live-recording")]
-pub mod recording;
 #[cfg(feature = "live-streaming")]
 pub mod streaming;
 
@@ -28,7 +26,7 @@ use std::sync::Arc;
 use std::time::Duration;
 
 #[cfg(feature = "live-recording")]
-pub use ffmpeg_recording::FfmpegLiveRecorder;
+pub use recording::FfmpegLiveRecorder;
 #[cfg(any(feature = "live-recording", feature = "live-streaming"))]
 pub use hls::{HlsPlaylist, HlsSegment, HlsVariant};
 #[cfg(feature = "live-recording")]

--- a/src/live/mod.rs
+++ b/src/live/mod.rs
@@ -66,17 +66,17 @@ pub struct RecordingConfig {
 /// Common configuration shared across live fragment streaming.
 #[cfg(feature = "live-streaming")]
 pub struct StreamRecordingConfig {
-    /// The HLS stream URL to record.
+    /// The HLS stream URL to stream live fragments from.
     pub stream_url: String,
     /// The video ID (for event emission).
     pub video_id: String,
     /// Quality label (e.g. "1080p").
     pub quality: String,
-    /// Optional maximum recording duration.
+    /// Optional maximum streaming duration for this live fragment session.
     pub max_duration: Option<Duration>,
     /// Cancellation token for graceful stop.
     pub cancellation_token: CancellationToken,
-    /// The event bus for emitting recording events.
+    /// The event bus for emitting streaming events.
     pub event_bus: crate::events::EventBus,
 }
 

--- a/src/live/mod.rs
+++ b/src/live/mod.rs
@@ -1,4 +1,4 @@
-//! Live stream recording module.
+//! Live stream recording and streaming module.
 //!
 //! Provides two recording engines for HLS live streams:
 //! - **Reqwest** (primary): Pure-Rust segment fetcher with zero-copy writes.
@@ -8,27 +8,44 @@
 //! and optionally bounded by a maximum duration. Events are emitted through
 //! the crate's event bus for progress tracking.
 
+#[cfg(any(feature = "live-recording", feature = "live-streaming"))]
+mod core;
+#[cfg(feature = "live-recording")]
 pub mod ffmpeg_recording;
+#[cfg(any(feature = "live-recording", feature = "live-streaming"))]
 pub mod hls;
+#[cfg(feature = "live-recording")]
 pub mod recording;
+#[cfg(feature = "live-streaming")]
+pub mod streaming;
 
+#[cfg(feature = "live-streaming")]
+pub use core::LiveFragment;
 use std::fmt;
+#[cfg(feature = "live-recording")]
 use std::path::PathBuf;
 use std::sync::Arc;
 use std::time::Duration;
 
+#[cfg(feature = "live-recording")]
 pub use ffmpeg_recording::FfmpegLiveRecorder;
+#[cfg(any(feature = "live-recording", feature = "live-streaming"))]
 pub use hls::{HlsPlaylist, HlsSegment, HlsVariant};
-pub use recording::{LiveFragment, LiveFragmentStream, LiveFragmentStreamer, LiveRecorder};
+#[cfg(feature = "live-recording")]
+pub use recording::LiveRecorder;
+#[cfg(feature = "live-streaming")]
+pub use streaming::{LiveFragmentStream, LiveFragmentStreamer};
 use tokio_util::sync::CancellationToken;
 
 use crate::Downloader;
 use crate::error::{Error, Result};
+#[cfg(feature = "live-recording")]
 use crate::events::types::RecordingMethod;
 use crate::model::Video;
 use crate::model::format::Format;
 
 /// Common configuration shared across live recording engines.
+#[cfg(feature = "live-recording")]
 pub struct RecordingConfig {
     /// The HLS stream URL to record.
     pub stream_url: String,
@@ -47,6 +64,7 @@ pub struct RecordingConfig {
 }
 
 /// Common configuration shared across live fragment streaming.
+#[cfg(feature = "live-streaming")]
 pub struct StreamRecordingConfig {
     /// The HLS stream URL to record.
     pub stream_url: String,
@@ -63,6 +81,7 @@ pub struct StreamRecordingConfig {
 }
 
 /// The result of a live recording session.
+#[cfg(feature = "live-recording")]
 #[derive(Debug, Clone)]
 pub struct RecordingResult {
     /// The path to the recorded file.
@@ -75,6 +94,7 @@ pub struct RecordingResult {
     pub segments_downloaded: u64,
 }
 
+#[cfg(feature = "live-recording")]
 impl fmt::Display for RecordingResult {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         write!(
@@ -115,6 +135,7 @@ impl fmt::Display for RecordingResult {
 /// # Ok(())
 /// # }
 /// ```
+#[cfg(feature = "live-recording")]
 pub struct LiveRecordingBuilder<'a> {
     downloader: &'a Downloader,
     video: &'a Video,
@@ -125,6 +146,7 @@ pub struct LiveRecordingBuilder<'a> {
     cancellation_token: Option<CancellationToken>,
 }
 
+#[cfg(feature = "live-recording")]
 impl<'a> LiveRecordingBuilder<'a> {
     /// Creates a new live recording builder.
     ///
@@ -200,7 +222,7 @@ impl<'a> LiveRecordingBuilder<'a> {
     ///
     /// A [`RecordingResult`] containing recording statistics.
     pub async fn execute(self) -> Result<RecordingResult> {
-        let resolved = resolve_live_format(self.video, self.format)?;
+        let resolved = resolve_live_format(self.video, self.format, LiveMode::Recording)?;
         let cancellation_token = self
             .cancellation_token
             .unwrap_or_else(|| self.downloader.cancellation_token.child_token());
@@ -257,6 +279,7 @@ impl<'a> LiveRecordingBuilder<'a> {
 ///
 /// Created via [`Downloader::stream_live`]. Allows configuring format selection,
 /// maximum duration, and cancellation token before starting.
+#[cfg(feature = "live-streaming")]
 pub struct LiveStreamBuilder<'a> {
     downloader: &'a Downloader,
     video: &'a Video,
@@ -265,6 +288,7 @@ pub struct LiveStreamBuilder<'a> {
     cancellation_token: Option<CancellationToken>,
 }
 
+#[cfg(feature = "live-streaming")]
 impl fmt::Debug for LiveStreamBuilder<'_> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         f.debug_struct("LiveStreamBuilder")
@@ -276,6 +300,7 @@ impl fmt::Debug for LiveStreamBuilder<'_> {
     }
 }
 
+#[cfg(feature = "live-streaming")]
 impl<'a> LiveStreamBuilder<'a> {
     /// Creates a new live stream builder.
     ///
@@ -338,7 +363,7 @@ impl<'a> LiveStreamBuilder<'a> {
     ///
     /// A [`LiveFragmentStream`] that yields HLS fragments as they are downloaded.
     pub async fn execute(self) -> Result<LiveFragmentStream> {
-        let resolved = resolve_live_format(self.video, self.format)?;
+        let resolved = resolve_live_format(self.video, self.format, LiveMode::Streaming)?;
         let cancellation_token = self
             .cancellation_token
             .unwrap_or_else(|| self.downloader.cancellation_token.child_token());
@@ -370,13 +395,24 @@ impl<'a> LiveStreamBuilder<'a> {
     }
 }
 
+#[cfg(any(feature = "live-recording", feature = "live-streaming"))]
 #[derive(Debug, Clone)]
 struct ResolvedLiveFormat {
     stream_url: String,
     quality: String,
 }
 
-fn resolve_live_format(video: &Video, format: Option<&Format>) -> Result<ResolvedLiveFormat> {
+#[cfg(any(feature = "live-recording", feature = "live-streaming"))]
+#[derive(Debug, Clone, Copy)]
+enum LiveMode {
+    #[cfg(feature = "live-recording")]
+    Recording,
+    #[cfg(feature = "live-streaming")]
+    Streaming,
+}
+
+#[cfg(any(feature = "live-recording", feature = "live-streaming"))]
+fn resolve_live_format(video: &Video, format: Option<&Format>, mode: LiveMode) -> Result<ResolvedLiveFormat> {
     if !video.is_currently_live() {
         return Err(Error::live_unavailable(
             video.webpage_url.as_deref().unwrap_or("unknown"),
@@ -388,12 +424,9 @@ fn resolve_live_format(video: &Video, format: Option<&Format>) -> Result<Resolve
     let live_formats = video.live_formats();
     let format = match format {
         Some(f) => f,
-        None => live_formats.last().ok_or_else(|| {
-            Error::live_recording(
-                video.webpage_url.as_deref().unwrap_or("unknown"),
-                "no HLS formats available",
-            )
-        })?,
+        None => live_formats
+            .last()
+            .ok_or_else(|| live_format_error(video, mode, "no HLS formats available"))?,
     };
 
     let stream_url = format.url()?.clone();
@@ -406,6 +439,19 @@ fn resolve_live_format(video: &Video, format: Option<&Format>) -> Result<Resolve
     Ok(ResolvedLiveFormat { stream_url, quality })
 }
 
+#[cfg(any(feature = "live-recording", feature = "live-streaming"))]
+fn live_format_error(video: &Video, mode: LiveMode, reason: &str) -> Error {
+    let url = video.webpage_url.as_deref().unwrap_or("unknown");
+
+    match mode {
+        #[cfg(feature = "live-recording")]
+        LiveMode::Recording => Error::live_recording(url, reason),
+        #[cfg(feature = "live-streaming")]
+        LiveMode::Streaming => Error::live_streaming(url, reason),
+    }
+}
+
+#[cfg(feature = "live-recording")]
 impl fmt::Debug for LiveRecordingBuilder<'_> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         f.debug_struct("LiveRecordingBuilder")

--- a/src/live/recording.rs
+++ b/src/live/recording.rs
@@ -1,3 +1,9 @@
+//! Reqwest-based live recording implementation.
+//!
+//! Polls the HLS media playlist, downloads new segments, and appends them to the
+//! output file. The loop stops on cancellation, stream end (`#EXT-X-ENDLIST`), or
+//! when the configured maximum duration elapses.
+
 use std::collections::HashSet;
 use std::fmt;
 use std::path::PathBuf;

--- a/src/live/recording.rs
+++ b/src/live/recording.rs
@@ -6,15 +6,17 @@
 //! and optionally bounded by a maximum duration.
 
 use std::collections::HashSet;
+use std::future::Future;
 use std::path::PathBuf;
 use std::sync::Arc;
 use std::sync::atomic::{AtomicU64, Ordering};
 use std::time::{Duration, Instant};
 
 use tokio::io::AsyncWriteExt;
+use tokio_stream::wrappers::ReceiverStream;
 use tokio_util::sync::CancellationToken;
 
-use super::{RecordingConfig, hls};
+use super::{RecordingConfig, StreamRecordingConfig, hls};
 use crate::error::{Error, Result};
 use crate::events::DownloadEvent;
 use crate::events::types::RecordingMethod;
@@ -28,28 +30,44 @@ const SEGMENT_RETRY_ATTEMPTS: u32 = 3;
 /// Delay between segment fetch retries.
 const SEGMENT_RETRY_DELAY: Duration = Duration::from_millis(500);
 
+/// Buffered writer capacity for recording output.
+const OUTPUT_BUFFER_CAPACITY: usize = 64 * 1024;
+
+/// Channel capacity for streaming fragments.
+const FRAGMENT_CHANNEL_CAPACITY: usize = 32;
+
+/// Divisor applied to target duration to derive poll interval.
+const POLL_INTERVAL_DIVISOR: f64 = 2.0;
+
+/// Bitrate conversion multiplier for bytes to bits.
+const BITS_PER_BYTE: f64 = 8.0;
+
+/// Result stream type for live fragment delivery.
+pub type LiveFragmentStream = ReceiverStream<Result<LiveFragment>>;
+
+/// A single live fragment downloaded from an HLS stream.
+#[derive(Debug, Clone)]
+pub struct LiveFragment {
+    /// The segment sequence number.
+    pub sequence: u64,
+    /// The segment duration.
+    pub duration: Duration,
+    /// The absolute URL for the fragment.
+    pub url: String,
+    /// The fragment bytes.
+    pub data: Vec<u8>,
+}
+
 /// Reqwest-based live stream recorder.
 ///
 /// Downloads HLS segments in order and writes them to a single output file.
 /// Designed for live streams where the media playlist is continuously updated.
 #[derive(Debug)]
 pub struct LiveRecorder {
-    /// The URL of the HLS media playlist to poll.
-    playlist_url: String,
+    /// Shared recording state and logic.
+    core: LiveRecordingCore,
     /// The output file path.
     output_path: PathBuf,
-    /// The video ID (for event emission).
-    video_id: String,
-    /// Optional maximum recording duration.
-    max_duration: Option<Duration>,
-    /// Cancellation token for graceful stop.
-    cancellation_token: CancellationToken,
-    /// Shared HTTP client.
-    client: Arc<reqwest::Client>,
-    /// The event bus for emitting recording events.
-    event_bus: crate::events::EventBus,
-    /// Quality label for event metadata.
-    quality: String,
 }
 
 impl LiveRecorder {
@@ -61,14 +79,17 @@ impl LiveRecorder {
     /// * `client` - Shared HTTP client.
     pub fn new(config: RecordingConfig, client: Arc<reqwest::Client>) -> Self {
         Self {
-            playlist_url: config.stream_url,
+            core: LiveRecordingCore::new(
+                config.stream_url,
+                config.video_id,
+                config.quality,
+                config.max_duration,
+                config.cancellation_token,
+                client,
+                config.event_bus,
+                Some(config.output_path.clone()),
+            ),
             output_path: config.output_path,
-            video_id: config.video_id,
-            quality: config.quality,
-            max_duration: config.max_duration,
-            cancellation_token: config.cancellation_token,
-            client,
-            event_bus: config.event_bus,
         }
     }
 
@@ -88,6 +109,173 @@ impl LiveRecorder {
     ///
     /// A [`super::RecordingResult`] with recording statistics.
     pub async fn record(&self) -> Result<super::RecordingResult> {
+        // Create output file with async buffered writer
+        if let Some(parent) = self.output_path.parent() {
+            tokio::fs::create_dir_all(parent).await?;
+        }
+        let file = tokio::fs::File::create(&self.output_path)
+            .await
+            .map_err(|e| Error::io_with_path("creating recording output", &self.output_path, e))?;
+        let mut writer = tokio::io::BufWriter::with_capacity(OUTPUT_BUFFER_CAPACITY, file);
+
+        let stats = self.core.record_to_writer(&mut writer, &self.output_path).await?;
+
+        tracing::info!(
+            video_id = self.core.video_id,
+            total_bytes = stats.total_bytes,
+            segments = stats.segments_downloaded,
+            duration = ?stats.total_duration,
+            reason = stats.stop_reason,
+            "✅ Live recording stopped"
+        );
+
+        Ok(super::RecordingResult {
+            output_path: self.output_path.clone(),
+            total_bytes: stats.total_bytes,
+            total_duration: stats.total_duration,
+            segments_downloaded: stats.segments_downloaded,
+        })
+    }
+}
+
+impl std::fmt::Display for LiveRecorder {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(
+            f,
+            "LiveRecorder(video_id={}, quality={}, output={})",
+            self.core.video_id,
+            self.core.quality,
+            self.output_path.display()
+        )
+    }
+}
+
+/// Streamer for live HLS fragments.
+#[derive(Debug)]
+pub struct LiveFragmentStreamer {
+    /// Shared recording state and logic.
+    core: LiveRecordingCore,
+}
+
+impl LiveFragmentStreamer {
+    /// Creates a new `LiveFragmentStreamer`.
+    ///
+    /// # Arguments
+    ///
+    /// * `config` - Common streaming configuration (URL, duration, events).
+    /// * `client` - Shared HTTP client.
+    pub fn new(config: StreamRecordingConfig, client: Arc<reqwest::Client>) -> Self {
+        Self {
+            core: LiveRecordingCore::new(
+                config.stream_url,
+                config.video_id,
+                config.quality,
+                config.max_duration,
+                config.cancellation_token,
+                client,
+                config.event_bus,
+                None,
+            ),
+        }
+    }
+
+    /// Starts streaming fragments from the live stream.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if the playlist or any segment cannot be fetched.
+    ///
+    /// # Returns
+    ///
+    /// A [`LiveFragmentStream`] that yields fragments as they arrive.
+    pub async fn stream(&self) -> Result<LiveFragmentStream> {
+        let (sender, receiver) = tokio::sync::mpsc::channel(FRAGMENT_CHANNEL_CAPACITY);
+        let core = self.core.clone();
+
+        tokio::spawn(async move {
+            let result = core
+                .run_loop(
+                    |fragment| async {
+                        if sender.send(Ok(fragment)).await.is_err() {
+                            core.cancellation_token.cancel();
+                            return Ok(());
+                        }
+                        Ok(())
+                    },
+                    || async { Ok(()) },
+                )
+                .await;
+
+            if let Err(error) = result {
+                core.event_bus.emit_if_subscribed(DownloadEvent::LiveStreamFailed {
+                    video_id: core.video_id.clone(),
+                    error: error.to_string(),
+                });
+                let _ = sender.send(Err(error)).await;
+            }
+        });
+
+        Ok(ReceiverStream::new(receiver))
+    }
+}
+
+#[derive(Debug, Clone)]
+struct LiveRecordingCore {
+    /// The URL of the HLS media playlist to poll.
+    playlist_url: String,
+    /// The video ID (for event emission).
+    video_id: String,
+    /// Quality label for event metadata.
+    quality: String,
+    /// Optional maximum recording duration.
+    max_duration: Option<Duration>,
+    /// Cancellation token for graceful stop.
+    cancellation_token: CancellationToken,
+    /// Shared HTTP client.
+    client: Arc<reqwest::Client>,
+    /// The event bus for emitting recording events.
+    event_bus: crate::events::EventBus,
+    /// Optional output path for recording mode.
+    output_path: Option<PathBuf>,
+}
+
+impl LiveRecordingCore {
+    #[allow(clippy::too_many_arguments)]
+    fn new(
+        playlist_url: String,
+        video_id: String,
+        quality: String,
+        max_duration: Option<Duration>,
+        cancellation_token: CancellationToken,
+        client: Arc<reqwest::Client>,
+        event_bus: crate::events::EventBus,
+        output_path: Option<PathBuf>,
+    ) -> Self {
+        Self {
+            playlist_url,
+            video_id,
+            quality,
+            max_duration,
+            cancellation_token,
+            client,
+            event_bus,
+            output_path,
+        }
+    }
+
+    async fn record_to_writer(
+        &self,
+        writer: &mut tokio::io::BufWriter<tokio::fs::File>,
+        output_path: &PathBuf,
+    ) -> Result<RecordingStats> {
+        self.record_loop(writer, output_path).await
+    }
+
+    async fn record_loop(
+        &self,
+        writer: &mut tokio::io::BufWriter<tokio::fs::File>,
+        output_path: &PathBuf,
+    ) -> Result<RecordingStats> {
         let start = Instant::now();
         let bytes_written = Arc::new(AtomicU64::new(0));
         let mut segments_downloaded: u64 = 0;
@@ -97,7 +285,6 @@ impl LiveRecorder {
         tracing::info!(
             url = self.playlist_url,
             video_id = self.video_id,
-            output = ?self.output_path,
             max_duration = ?self.max_duration,
             "📥 Starting live recording (reqwest)"
         );
@@ -109,41 +296,179 @@ impl LiveRecorder {
             method: RecordingMethod::Native,
         });
 
-        // Create output file with async buffered writer
-        if let Some(parent) = self.output_path.parent() {
-            tokio::fs::create_dir_all(parent).await?;
+        let initial = hls::parse_media(&self.client, &self.playlist_url).await?;
+        let poll_interval = Duration::from_secs_f64(initial.target_duration / POLL_INTERVAL_DIVISOR);
+
+        for seg in &initial.segments {
+            seen_sequences.insert(seg.sequence);
         }
-        let file = tokio::fs::File::create(&self.output_path)
+
+        for seg in &initial.segments {
+            if self.cancellation_token.is_cancelled() {
+                break;
+            }
+
+            let fragment = self.fetch_fragment(seg).await?;
+            writer
+                .write_all(&fragment.data)
+                .await
+                .map_err(|e| Error::io_with_path("writing segment", output_path, e))?;
+            bytes_written.fetch_add(fragment.data.len() as u64, Ordering::Relaxed);
+            segments_downloaded += 1;
+        }
+
+        writer
+            .flush()
             .await
-            .map_err(|e| Error::io_with_path("creating recording output", &self.output_path, e))?;
-        let mut writer = tokio::io::BufWriter::with_capacity(64 * 1024, file);
+            .map_err(|e| Error::io_with_path("flushing output", output_path, e))?;
+
+        let stop_reason = loop {
+            if let Some(max) = self.max_duration
+                && start.elapsed() >= max
+            {
+                break "max duration reached".to_string();
+            }
+
+            tokio::select! {
+                _ = self.cancellation_token.cancelled() => {
+                    break "cancelled".to_string();
+                }
+                _ = tokio::time::sleep(poll_interval) => {}
+            }
+
+            let playlist = match hls::parse_media(&self.client, &self.playlist_url).await {
+                Ok(p) => p,
+                Err(e) => {
+                    tracing::warn!(error = %e, "HLS playlist fetch failed, retrying next cycle");
+                    continue;
+                }
+            };
+
+            if playlist.is_endlist && playlist.segments.iter().all(|s| seen_sequences.contains(&s.sequence)) {
+                break "stream ended".to_string();
+            }
+
+            let new_segments: Vec<_> = playlist
+                .segments
+                .iter()
+                .filter(|s| !seen_sequences.contains(&s.sequence))
+                .collect();
+
+            for seg in &new_segments {
+                if self.cancellation_token.is_cancelled() {
+                    break;
+                }
+
+                let fragment = self.fetch_fragment(seg).await?;
+                writer
+                    .write_all(&fragment.data)
+                    .await
+                    .map_err(|e| Error::io_with_path("writing segment", output_path, e))?;
+                bytes_written.fetch_add(fragment.data.len() as u64, Ordering::Relaxed);
+                segments_downloaded += 1;
+                seen_sequences.insert(seg.sequence);
+            }
+
+            writer
+                .flush()
+                .await
+                .map_err(|e| Error::io_with_path("flushing output", output_path, e))?;
+
+            let now_nanos = start.elapsed().as_nanos() as u64;
+            if now_nanos - last_progress_nanos >= PROGRESS_THROTTLE_NANOS {
+                last_progress_nanos = now_nanos;
+                let total_bytes = bytes_written.load(Ordering::Relaxed);
+                let elapsed = start.elapsed();
+                let bitrate_bps = if elapsed.as_secs_f64() > 0.0 {
+                    (total_bytes as f64 * BITS_PER_BYTE) / elapsed.as_secs_f64()
+                } else {
+                    0.0
+                };
+
+                self.event_bus.emit_if_subscribed(DownloadEvent::LiveStreamProgress {
+                    video_id: self.video_id.clone(),
+                    elapsed,
+                    bytes_received: total_bytes,
+                    segments: segments_downloaded,
+                    bitrate_bps,
+                });
+            }
+
+            if playlist.is_endlist {
+                break "stream ended".to_string();
+            }
+        };
+
+        let total_duration = start.elapsed();
+        let total_bytes = bytes_written.load(Ordering::Relaxed);
+
+        let output_path = self
+            .output_path
+            .clone()
+            .ok_or_else(|| Error::live_recording(&self.playlist_url, "missing output path for recording"))?;
+
+        self.event_bus.emit_if_subscribed(DownloadEvent::LiveRecordingStopped {
+            video_id: self.video_id.clone(),
+            reason: stop_reason.clone(),
+            output_path,
+            total_bytes,
+            total_duration,
+        });
+
+        Ok(RecordingStats {
+            total_bytes,
+            total_duration,
+            segments_downloaded,
+            stop_reason,
+        })
+    }
+
+    async fn run_loop<F, Fut, B, BFut>(&self, mut on_fragment: F, mut on_batch: B) -> Result<RecordingStats>
+    where
+        F: FnMut(LiveFragment) -> Fut,
+        Fut: Future<Output = Result<()>>,
+        B: FnMut() -> BFut,
+        BFut: Future<Output = Result<()>>,
+    {
+        let start = Instant::now();
+        let bytes_written = Arc::new(AtomicU64::new(0));
+        let mut segments_downloaded: u64 = 0;
+        let mut seen_sequences: HashSet<u64> = HashSet::new();
+        let mut last_progress_nanos: u64 = 0;
+
+        tracing::info!(
+            url = self.playlist_url,
+            video_id = self.video_id,
+            max_duration = ?self.max_duration,
+            "📥 Starting live streaming (reqwest)"
+        );
+
+        self.event_bus.emit_if_subscribed(DownloadEvent::LiveStreamStarted {
+            video_id: self.video_id.clone(),
+            url: self.playlist_url.clone(),
+            quality: self.quality.clone(),
+        });
 
         // Initial playlist fetch to determine poll interval
         let initial = hls::parse_media(&self.client, &self.playlist_url).await?;
-        let poll_interval = Duration::from_secs_f64(initial.target_duration / 2.0);
+        let poll_interval = Duration::from_secs_f64(initial.target_duration / POLL_INTERVAL_DIVISOR);
 
         // Seed seen set with initial segments (don't re-download them)
         for seg in &initial.segments {
             seen_sequences.insert(seg.sequence);
         }
 
-        // Download initial segments to start the file
+        // Download initial segments to start the output
         for seg in &initial.segments {
             if self.cancellation_token.is_cancelled() {
                 break;
             }
-            let data = self.fetch_segment(&seg.url).await?;
-            writer
-                .write_all(&data)
-                .await
-                .map_err(|e| Error::io_with_path("writing segment", &self.output_path, e))?;
-            bytes_written.fetch_add(data.len() as u64, Ordering::Relaxed);
+            let fragment = self.fetch_fragment(seg).await?;
+            bytes_written.fetch_add(fragment.data.len() as u64, Ordering::Relaxed);
             segments_downloaded += 1;
+            on_fragment(fragment).await?;
         }
-        writer
-            .flush()
-            .await
-            .map_err(|e| Error::io_with_path("flushing output", &self.output_path, e))?;
+        on_batch().await?;
 
         // Poll loop
         let stop_reason = loop {
@@ -188,19 +513,13 @@ impl LiveRecorder {
                     break;
                 }
 
-                let data = self.fetch_segment(&seg.url).await?;
-                writer
-                    .write_all(&data)
-                    .await
-                    .map_err(|e| Error::io_with_path("writing segment", &self.output_path, e))?;
-                bytes_written.fetch_add(data.len() as u64, Ordering::Relaxed);
+                let fragment = self.fetch_fragment(seg).await?;
+                bytes_written.fetch_add(fragment.data.len() as u64, Ordering::Relaxed);
                 segments_downloaded += 1;
                 seen_sequences.insert(seg.sequence);
+                on_fragment(fragment).await?;
             }
-            writer
-                .flush()
-                .await
-                .map_err(|e| Error::io_with_path("flushing output", &self.output_path, e))?;
+            on_batch().await?;
 
             // Emit progress (throttled)
             let now_nanos = start.elapsed().as_nanos() as u64;
@@ -209,7 +528,7 @@ impl LiveRecorder {
                 let total_bytes = bytes_written.load(Ordering::Relaxed);
                 let elapsed = start.elapsed();
                 let bitrate_bps = if elapsed.as_secs_f64() > 0.0 {
-                    (total_bytes as f64 * 8.0) / elapsed.as_secs_f64()
+                    (total_bytes as f64 * BITS_PER_BYTE) / elapsed.as_secs_f64()
                 } else {
                     0.0
                 };
@@ -229,31 +548,21 @@ impl LiveRecorder {
             }
         };
 
-        let total_bytes = bytes_written.load(Ordering::Relaxed);
         let total_duration = start.elapsed();
+        let total_bytes = bytes_written.load(Ordering::Relaxed);
 
-        tracing::info!(
-            video_id = self.video_id,
-            total_bytes = total_bytes,
-            segments = segments_downloaded,
-            duration = ?total_duration,
-            reason = stop_reason,
-            "✅ Live recording stopped"
-        );
-
-        self.event_bus.emit_if_subscribed(DownloadEvent::LiveRecordingStopped {
+        self.event_bus.emit_if_subscribed(DownloadEvent::LiveStreamStopped {
             video_id: self.video_id.clone(),
-            reason: stop_reason,
-            output_path: self.output_path.clone(),
+            reason: stop_reason.clone(),
             total_bytes,
             total_duration,
         });
 
-        Ok(super::RecordingResult {
-            output_path: self.output_path.clone(),
+        Ok(RecordingStats {
             total_bytes,
             total_duration,
             segments_downloaded,
+            stop_reason,
         })
     }
 
@@ -306,16 +615,22 @@ impl LiveRecorder {
 
         Ok(bytes.to_vec())
     }
+
+    async fn fetch_fragment(&self, segment: &hls::HlsSegment) -> Result<LiveFragment> {
+        let data = self.fetch_segment(&segment.url).await?;
+        Ok(LiveFragment {
+            sequence: segment.sequence,
+            duration: Duration::from_secs_f64(segment.duration),
+            url: segment.url.clone(),
+            data,
+        })
+    }
 }
 
-impl std::fmt::Display for LiveRecorder {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        write!(
-            f,
-            "LiveRecorder(video_id={}, quality={}, output={})",
-            self.video_id,
-            self.quality,
-            self.output_path.display()
-        )
-    }
+#[derive(Debug, Clone)]
+struct RecordingStats {
+    total_bytes: u64,
+    total_duration: Duration,
+    segments_downloaded: u64,
+    stop_reason: String,
 }

--- a/src/live/recording.rs
+++ b/src/live/recording.rs
@@ -1,62 +1,23 @@
-//! Pure-Rust live stream recorder using reqwest for HLS segment fetching.
-//!
-//! This is the primary recording engine. It polls the HLS media playlist,
-//! downloads new segments as they appear, and writes them sequentially to
-//! the output file. The recording loop is cancellable via a `CancellationToken`
-//! and optionally bounded by a maximum duration.
-
 use std::collections::HashSet;
-use std::future::Future;
+use std::fmt;
 use std::path::PathBuf;
 use std::sync::Arc;
 use std::sync::atomic::{AtomicU64, Ordering};
 use std::time::{Duration, Instant};
 
-use tokio::io::AsyncWriteExt;
-use tokio_stream::wrappers::ReceiverStream;
-use tokio_util::sync::CancellationToken;
+use tokio::io::{AsyncWriteExt, BufWriter};
+use tokio::{fs, time};
 
-use super::{RecordingConfig, StreamRecordingConfig, hls};
+use super::core::{
+    BITS_PER_BYTE, LiveCore, PROGRESS_THROTTLE_NANOS, RecordingStats, SegmentErrorMode, ZERO_F64, ZERO_U64,
+};
+use super::{RecordingConfig, hls};
 use crate::error::{Error, Result};
 use crate::events::DownloadEvent;
 use crate::events::types::RecordingMethod;
 
-/// Progress throttle interval (50 ms) to avoid flooding the event bus.
-const PROGRESS_THROTTLE_NANOS: u64 = 50_000_000;
-
-/// Maximum number of retry attempts per segment fetch.
-const SEGMENT_RETRY_ATTEMPTS: u32 = 3;
-
-/// Delay between segment fetch retries.
-const SEGMENT_RETRY_DELAY: Duration = Duration::from_millis(500);
-
 /// Buffered writer capacity for recording output.
 const OUTPUT_BUFFER_CAPACITY: usize = 64 * 1024;
-
-/// Channel capacity for streaming fragments.
-const FRAGMENT_CHANNEL_CAPACITY: usize = 32;
-
-/// Divisor applied to target duration to derive poll interval.
-const POLL_INTERVAL_DIVISOR: f64 = 2.0;
-
-/// Bitrate conversion multiplier for bytes to bits.
-const BITS_PER_BYTE: f64 = 8.0;
-
-/// Result stream type for live fragment delivery.
-pub type LiveFragmentStream = ReceiverStream<Result<LiveFragment>>;
-
-/// A single live fragment downloaded from an HLS stream.
-#[derive(Debug, Clone)]
-pub struct LiveFragment {
-    /// The segment sequence number.
-    pub sequence: u64,
-    /// The segment duration.
-    pub duration: Duration,
-    /// The absolute URL for the fragment.
-    pub url: String,
-    /// The fragment bytes.
-    pub data: Vec<u8>,
-}
 
 /// Reqwest-based live stream recorder.
 ///
@@ -65,7 +26,7 @@ pub struct LiveFragment {
 #[derive(Debug)]
 pub struct LiveRecorder {
     /// Shared recording state and logic.
-    core: LiveRecordingCore,
+    core: LiveCore,
     /// The output file path.
     output_path: PathBuf,
 }
@@ -79,7 +40,7 @@ impl LiveRecorder {
     /// * `client` - Shared HTTP client.
     pub fn new(config: RecordingConfig, client: Arc<reqwest::Client>) -> Self {
         Self {
-            core: LiveRecordingCore::new(
+            core: LiveCore::new(
                 config.stream_url,
                 config.video_id,
                 config.quality,
@@ -109,16 +70,15 @@ impl LiveRecorder {
     ///
     /// A [`super::RecordingResult`] with recording statistics.
     pub async fn record(&self) -> Result<super::RecordingResult> {
-        // Create output file with async buffered writer
         if let Some(parent) = self.output_path.parent() {
-            tokio::fs::create_dir_all(parent).await?;
+            fs::create_dir_all(parent).await?;
         }
-        let file = tokio::fs::File::create(&self.output_path)
+        let file = fs::File::create(&self.output_path)
             .await
             .map_err(|e| Error::io_with_path("creating recording output", &self.output_path, e))?;
-        let mut writer = tokio::io::BufWriter::with_capacity(OUTPUT_BUFFER_CAPACITY, file);
+        let mut writer = BufWriter::with_capacity(OUTPUT_BUFFER_CAPACITY, file);
 
-        let stats = self.core.record_to_writer(&mut writer, &self.output_path).await?;
+        let stats = self.record_to_writer(&mut writer, &self.output_path).await?;
 
         tracing::info!(
             video_id = self.core.video_id,
@@ -136,185 +96,58 @@ impl LiveRecorder {
             segments_downloaded: stats.segments_downloaded,
         })
     }
-}
-
-impl std::fmt::Display for LiveRecorder {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        write!(
-            f,
-            "LiveRecorder(video_id={}, quality={}, output={})",
-            self.core.video_id,
-            self.core.quality,
-            self.output_path.display()
-        )
-    }
-}
-
-/// Streamer for live HLS fragments.
-#[derive(Debug)]
-pub struct LiveFragmentStreamer {
-    /// Shared recording state and logic.
-    core: LiveRecordingCore,
-}
-
-impl LiveFragmentStreamer {
-    /// Creates a new `LiveFragmentStreamer`.
-    ///
-    /// # Arguments
-    ///
-    /// * `config` - Common streaming configuration (URL, duration, events).
-    /// * `client` - Shared HTTP client.
-    pub fn new(config: StreamRecordingConfig, client: Arc<reqwest::Client>) -> Self {
-        Self {
-            core: LiveRecordingCore::new(
-                config.stream_url,
-                config.video_id,
-                config.quality,
-                config.max_duration,
-                config.cancellation_token,
-                client,
-                config.event_bus,
-                None,
-            ),
-        }
-    }
-
-    /// Starts streaming fragments from the live stream.
-    ///
-    /// # Errors
-    ///
-    /// Returns an error if the playlist or any segment cannot be fetched.
-    ///
-    /// # Returns
-    ///
-    /// A [`LiveFragmentStream`] that yields fragments as they arrive.
-    pub async fn stream(&self) -> Result<LiveFragmentStream> {
-        let (sender, receiver) = tokio::sync::mpsc::channel(FRAGMENT_CHANNEL_CAPACITY);
-        let core = self.core.clone();
-
-        tokio::spawn(async move {
-            let result = core
-                .run_loop(
-                    |fragment| async {
-                        if sender.send(Ok(fragment)).await.is_err() {
-                            core.cancellation_token.cancel();
-                            return Ok(());
-                        }
-                        Ok(())
-                    },
-                    || async { Ok(()) },
-                )
-                .await;
-
-            if let Err(error) = result {
-                core.event_bus.emit_if_subscribed(DownloadEvent::LiveStreamFailed {
-                    video_id: core.video_id.clone(),
-                    error: error.to_string(),
-                });
-                let _ = sender.send(Err(error)).await;
-            }
-        });
-
-        Ok(ReceiverStream::new(receiver))
-    }
-}
-
-#[derive(Debug, Clone)]
-struct LiveRecordingCore {
-    /// The URL of the HLS media playlist to poll.
-    playlist_url: String,
-    /// The video ID (for event emission).
-    video_id: String,
-    /// Quality label for event metadata.
-    quality: String,
-    /// Optional maximum recording duration.
-    max_duration: Option<Duration>,
-    /// Cancellation token for graceful stop.
-    cancellation_token: CancellationToken,
-    /// Shared HTTP client.
-    client: Arc<reqwest::Client>,
-    /// The event bus for emitting recording events.
-    event_bus: crate::events::EventBus,
-    /// Optional output path for recording mode.
-    output_path: Option<PathBuf>,
-}
-
-impl LiveRecordingCore {
-    #[allow(clippy::too_many_arguments)]
-    fn new(
-        playlist_url: String,
-        video_id: String,
-        quality: String,
-        max_duration: Option<Duration>,
-        cancellation_token: CancellationToken,
-        client: Arc<reqwest::Client>,
-        event_bus: crate::events::EventBus,
-        output_path: Option<PathBuf>,
-    ) -> Self {
-        Self {
-            playlist_url,
-            video_id,
-            quality,
-            max_duration,
-            cancellation_token,
-            client,
-            event_bus,
-            output_path,
-        }
-    }
 
     async fn record_to_writer(
         &self,
-        writer: &mut tokio::io::BufWriter<tokio::fs::File>,
+        writer: &mut BufWriter<fs::File>,
         output_path: &PathBuf,
     ) -> Result<RecordingStats> {
         self.record_loop(writer, output_path).await
     }
 
-    async fn record_loop(
-        &self,
-        writer: &mut tokio::io::BufWriter<tokio::fs::File>,
-        output_path: &PathBuf,
-    ) -> Result<RecordingStats> {
+    async fn record_loop(&self, writer: &mut BufWriter<fs::File>, output_path: &PathBuf) -> Result<RecordingStats> {
         let start = Instant::now();
-        let bytes_written = Arc::new(AtomicU64::new(0));
-        let mut segments_downloaded: u64 = 0;
+        let bytes_written = Arc::new(AtomicU64::new(ZERO_U64));
+        let mut segments_downloaded: u64 = ZERO_U64;
         let mut seen_sequences: HashSet<u64> = HashSet::new();
-        let mut last_progress_nanos: u64 = 0;
+        let mut last_progress_nanos: u64 = ZERO_U64;
 
         tracing::info!(
-            url = self.playlist_url,
-            video_id = self.video_id,
-            max_duration = ?self.max_duration,
+            url = self.core.playlist_url,
+            video_id = self.core.video_id,
+            max_duration = ?self.core.max_duration,
             "📥 Starting live recording (reqwest)"
         );
 
-        self.event_bus.emit_if_subscribed(DownloadEvent::LiveRecordingStarted {
-            video_id: self.video_id.clone(),
-            url: self.playlist_url.clone(),
-            quality: self.quality.clone(),
-            method: RecordingMethod::Native,
-        });
+        self.core
+            .event_bus
+            .emit_if_subscribed(DownloadEvent::LiveRecordingStarted {
+                video_id: self.core.video_id.clone(),
+                url: self.core.playlist_url.clone(),
+                quality: self.core.quality.clone(),
+                method: RecordingMethod::Native,
+            });
 
-        let initial = hls::parse_media(&self.client, &self.playlist_url).await?;
-        let poll_interval = Duration::from_secs_f64(initial.target_duration / POLL_INTERVAL_DIVISOR);
+        let initial = hls::parse_media(&self.core.client, &self.core.playlist_url).await?;
+        let poll_interval = Duration::from_secs_f64(initial.target_duration / super::core::POLL_INTERVAL_DIVISOR);
 
         for seg in &initial.segments {
             seen_sequences.insert(seg.sequence);
         }
 
         for seg in &initial.segments {
-            if self.cancellation_token.is_cancelled() {
+            if self.core.cancellation_token.is_cancelled() {
                 break;
             }
 
-            let fragment = self.fetch_fragment(seg).await?;
+            let fragment = self.core.fetch_fragment(seg, SegmentErrorMode::Recording).await?;
             writer
                 .write_all(&fragment.data)
                 .await
                 .map_err(|e| Error::io_with_path("writing segment", output_path, e))?;
             bytes_written.fetch_add(fragment.data.len() as u64, Ordering::Relaxed);
             segments_downloaded += 1;
+            seen_sequences.insert(seg.sequence);
         }
 
         writer
@@ -323,20 +156,20 @@ impl LiveRecordingCore {
             .map_err(|e| Error::io_with_path("flushing output", output_path, e))?;
 
         let stop_reason = loop {
-            if let Some(max) = self.max_duration
+            if let Some(max) = self.core.max_duration
                 && start.elapsed() >= max
             {
                 break "max duration reached".to_string();
             }
 
             tokio::select! {
-                _ = self.cancellation_token.cancelled() => {
+                _ = self.core.cancellation_token.cancelled() => {
                     break "cancelled".to_string();
                 }
-                _ = tokio::time::sleep(poll_interval) => {}
+                _ = time::sleep(poll_interval) => {}
             }
 
-            let playlist = match hls::parse_media(&self.client, &self.playlist_url).await {
+            let playlist = match hls::parse_media(&self.core.client, &self.core.playlist_url).await {
                 Ok(p) => p,
                 Err(e) => {
                     tracing::warn!(error = %e, "HLS playlist fetch failed, retrying next cycle");
@@ -355,11 +188,11 @@ impl LiveRecordingCore {
                 .collect();
 
             for seg in &new_segments {
-                if self.cancellation_token.is_cancelled() {
+                if self.core.cancellation_token.is_cancelled() {
                     break;
                 }
 
-                let fragment = self.fetch_fragment(seg).await?;
+                let fragment = self.core.fetch_fragment(seg, SegmentErrorMode::Recording).await?;
                 writer
                     .write_all(&fragment.data)
                     .await
@@ -379,19 +212,21 @@ impl LiveRecordingCore {
                 last_progress_nanos = now_nanos;
                 let total_bytes = bytes_written.load(Ordering::Relaxed);
                 let elapsed = start.elapsed();
-                let bitrate_bps = if elapsed.as_secs_f64() > 0.0 {
+                let bitrate_bps = if elapsed.as_secs_f64() > ZERO_F64 {
                     (total_bytes as f64 * BITS_PER_BYTE) / elapsed.as_secs_f64()
                 } else {
-                    0.0
+                    ZERO_F64
                 };
 
-                self.event_bus.emit_if_subscribed(DownloadEvent::LiveStreamProgress {
-                    video_id: self.video_id.clone(),
-                    elapsed,
-                    bytes_received: total_bytes,
-                    segments: segments_downloaded,
-                    bitrate_bps,
-                });
+                self.core
+                    .event_bus
+                    .emit_if_subscribed(DownloadEvent::LiveRecordingProgress {
+                        video_id: self.core.video_id.clone(),
+                        elapsed,
+                        bytes_written: total_bytes,
+                        segments: segments_downloaded,
+                        bitrate_bps,
+                    });
             }
 
             if playlist.is_endlist {
@@ -403,234 +238,38 @@ impl LiveRecordingCore {
         let total_bytes = bytes_written.load(Ordering::Relaxed);
 
         let output_path = self
+            .core
             .output_path
             .clone()
-            .ok_or_else(|| Error::live_recording(&self.playlist_url, "missing output path for recording"))?;
+            .ok_or_else(|| Error::live_recording(&self.core.playlist_url, "missing output path for recording"))?;
 
-        self.event_bus.emit_if_subscribed(DownloadEvent::LiveRecordingStopped {
-            video_id: self.video_id.clone(),
-            reason: stop_reason.clone(),
-            output_path,
-            total_bytes,
-            total_duration,
-        });
-
-        Ok(RecordingStats {
-            total_bytes,
-            total_duration,
-            segments_downloaded,
-            stop_reason,
-        })
-    }
-
-    async fn run_loop<F, Fut, B, BFut>(&self, mut on_fragment: F, mut on_batch: B) -> Result<RecordingStats>
-    where
-        F: FnMut(LiveFragment) -> Fut,
-        Fut: Future<Output = Result<()>>,
-        B: FnMut() -> BFut,
-        BFut: Future<Output = Result<()>>,
-    {
-        let start = Instant::now();
-        let bytes_written = Arc::new(AtomicU64::new(0));
-        let mut segments_downloaded: u64 = 0;
-        let mut seen_sequences: HashSet<u64> = HashSet::new();
-        let mut last_progress_nanos: u64 = 0;
-
-        tracing::info!(
-            url = self.playlist_url,
-            video_id = self.video_id,
-            max_duration = ?self.max_duration,
-            "📥 Starting live streaming (reqwest)"
-        );
-
-        self.event_bus.emit_if_subscribed(DownloadEvent::LiveStreamStarted {
-            video_id: self.video_id.clone(),
-            url: self.playlist_url.clone(),
-            quality: self.quality.clone(),
-        });
-
-        // Initial playlist fetch to determine poll interval
-        let initial = hls::parse_media(&self.client, &self.playlist_url).await?;
-        let poll_interval = Duration::from_secs_f64(initial.target_duration / POLL_INTERVAL_DIVISOR);
-
-        // Seed seen set with initial segments (don't re-download them)
-        for seg in &initial.segments {
-            seen_sequences.insert(seg.sequence);
-        }
-
-        // Download initial segments to start the output
-        for seg in &initial.segments {
-            if self.cancellation_token.is_cancelled() {
-                break;
-            }
-            let fragment = self.fetch_fragment(seg).await?;
-            bytes_written.fetch_add(fragment.data.len() as u64, Ordering::Relaxed);
-            segments_downloaded += 1;
-            on_fragment(fragment).await?;
-        }
-        on_batch().await?;
-
-        // Poll loop
-        let stop_reason = loop {
-            // Check max duration
-            if let Some(max) = self.max_duration
-                && start.elapsed() >= max
-            {
-                break "max duration reached".to_string();
-            }
-
-            // Wait for next poll or cancellation
-            tokio::select! {
-                _ = self.cancellation_token.cancelled() => {
-                    break "cancelled".to_string();
-                }
-                _ = tokio::time::sleep(poll_interval) => {}
-            }
-
-            // Fetch updated playlist
-            let playlist = match hls::parse_media(&self.client, &self.playlist_url).await {
-                Ok(p) => p,
-                Err(e) => {
-                    tracing::warn!(error = %e, "HLS playlist fetch failed, retrying next cycle");
-                    continue;
-                }
-            };
-
-            // Stream ended
-            if playlist.is_endlist && playlist.segments.iter().all(|s| seen_sequences.contains(&s.sequence)) {
-                break "stream ended".to_string();
-            }
-
-            // Download new segments
-            let new_segments: Vec<_> = playlist
-                .segments
-                .iter()
-                .filter(|s| !seen_sequences.contains(&s.sequence))
-                .collect();
-
-            for seg in &new_segments {
-                if self.cancellation_token.is_cancelled() {
-                    break;
-                }
-
-                let fragment = self.fetch_fragment(seg).await?;
-                bytes_written.fetch_add(fragment.data.len() as u64, Ordering::Relaxed);
-                segments_downloaded += 1;
-                seen_sequences.insert(seg.sequence);
-                on_fragment(fragment).await?;
-            }
-            on_batch().await?;
-
-            // Emit progress (throttled)
-            let now_nanos = start.elapsed().as_nanos() as u64;
-            if now_nanos - last_progress_nanos >= PROGRESS_THROTTLE_NANOS {
-                last_progress_nanos = now_nanos;
-                let total_bytes = bytes_written.load(Ordering::Relaxed);
-                let elapsed = start.elapsed();
-                let bitrate_bps = if elapsed.as_secs_f64() > 0.0 {
-                    (total_bytes as f64 * BITS_PER_BYTE) / elapsed.as_secs_f64()
-                } else {
-                    0.0
-                };
-
-                self.event_bus.emit_if_subscribed(DownloadEvent::LiveRecordingProgress {
-                    video_id: self.video_id.clone(),
-                    elapsed,
-                    bytes_written: total_bytes,
-                    segments: segments_downloaded,
-                    bitrate_bps,
-                });
-            }
-
-            // If endlist was seen, stop after downloading remaining
-            if playlist.is_endlist {
-                break "stream ended".to_string();
-            }
-        };
-
-        let total_duration = start.elapsed();
-        let total_bytes = bytes_written.load(Ordering::Relaxed);
-
-        self.event_bus.emit_if_subscribed(DownloadEvent::LiveStreamStopped {
-            video_id: self.video_id.clone(),
-            reason: stop_reason.clone(),
-            total_bytes,
-            total_duration,
-        });
+        self.core
+            .event_bus
+            .emit_if_subscribed(DownloadEvent::LiveRecordingStopped {
+                video_id: self.core.video_id.clone(),
+                reason: stop_reason.clone(),
+                output_path,
+                total_bytes,
+                total_duration,
+            });
 
         Ok(RecordingStats {
             total_bytes,
             total_duration,
             segments_downloaded,
             stop_reason,
-        })
-    }
-
-    /// Fetches a single segment's bytes with retries.
-    async fn fetch_segment(&self, url: &str) -> Result<Vec<u8>> {
-        let mut last_error = None;
-
-        for attempt in 1..=SEGMENT_RETRY_ATTEMPTS {
-            match self.fetch_segment_once(url).await {
-                Ok(data) => return Ok(data),
-                Err(e) => {
-                    if attempt < SEGMENT_RETRY_ATTEMPTS {
-                        tracing::warn!(
-                            url = url,
-                            attempt = attempt,
-                            max_attempts = SEGMENT_RETRY_ATTEMPTS,
-                            error = %e,
-                            "Segment fetch failed, retrying"
-                        );
-                        tokio::time::sleep(SEGMENT_RETRY_DELAY).await;
-                    }
-                    last_error = Some(e);
-                }
-            }
-        }
-
-        Err(last_error.unwrap())
-    }
-
-    /// Single attempt to fetch a segment.
-    async fn fetch_segment_once(&self, url: &str) -> Result<Vec<u8>> {
-        let response = self
-            .client
-            .get(url)
-            .send()
-            .await
-            .map_err(|e| Error::http(url, "fetching HLS segment", e))?;
-
-        if !response.status().is_success() {
-            return Err(Error::live_recording(
-                url,
-                format!("segment fetch returned HTTP {}", response.status()),
-            ));
-        }
-
-        let bytes = response
-            .bytes()
-            .await
-            .map_err(|e| Error::http(url, "reading segment body", e))?;
-
-        Ok(bytes.to_vec())
-    }
-
-    async fn fetch_fragment(&self, segment: &hls::HlsSegment) -> Result<LiveFragment> {
-        let data = self.fetch_segment(&segment.url).await?;
-        Ok(LiveFragment {
-            sequence: segment.sequence,
-            duration: Duration::from_secs_f64(segment.duration),
-            url: segment.url.clone(),
-            data,
         })
     }
 }
 
-#[derive(Debug, Clone)]
-struct RecordingStats {
-    total_bytes: u64,
-    total_duration: Duration,
-    segments_downloaded: u64,
-    stop_reason: String,
+impl fmt::Display for LiveRecorder {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(
+            f,
+            "LiveRecorder(video_id={}, quality={}, output={})",
+            self.core.video_id,
+            self.core.quality,
+            self.output_path.display()
+        )
+    }
 }

--- a/src/live/recording/ffmpeg.rs
+++ b/src/live/recording/ffmpeg.rs
@@ -9,7 +9,7 @@ use std::time::{Duration, Instant};
 
 use tokio_util::sync::CancellationToken;
 
-use super::RecordingConfig;
+use super::super::RecordingConfig;
 use crate::error::Result;
 use crate::events::DownloadEvent;
 use crate::events::types::RecordingMethod;
@@ -72,8 +72,8 @@ impl FfmpegLiveRecorder {
     ///
     /// # Returns
     ///
-    /// A [`super::RecordingResult`] with recording statistics.
-    pub async fn record(&self) -> Result<super::RecordingResult> {
+    /// A [`super::super::RecordingResult`] with recording statistics.
+    pub async fn record(&self) -> Result<super::super::RecordingResult> {
         let start = Instant::now();
 
         tracing::info!(
@@ -169,7 +169,7 @@ impl FfmpegLiveRecorder {
             total_duration,
         });
 
-        Ok(super::RecordingResult {
+        Ok(super::super::RecordingResult {
             output_path: self.output_path.clone(),
             total_bytes,
             total_duration,

--- a/src/live/recording/mod.rs
+++ b/src/live/recording/mod.rs
@@ -1,0 +1,15 @@
+//! Live recording engines.
+//!
+//! Groups the two recording implementations:
+//! - [`native`]: Reqwest-based HLS segment recorder (primary).
+//! - [`ffmpeg`]: FFmpeg-based recorder (fallback).
+
+#[cfg(feature = "live-recording")]
+pub mod ffmpeg;
+#[cfg(feature = "live-recording")]
+pub mod native;
+
+#[cfg(feature = "live-recording")]
+pub use ffmpeg::FfmpegLiveRecorder;
+#[cfg(feature = "live-recording")]
+pub use native::LiveRecorder;

--- a/src/live/recording/native.rs
+++ b/src/live/recording/native.rs
@@ -14,10 +14,11 @@ use std::time::{Duration, Instant};
 use tokio::io::{AsyncWriteExt, BufWriter};
 use tokio::{fs, time};
 
-use super::core::{
-    BITS_PER_BYTE, LiveCore, PROGRESS_THROTTLE_NANOS, RecordingStats, SegmentErrorMode, ZERO_F64, ZERO_U64,
+use super::super::core::{
+    BITS_PER_BYTE, LiveCore, LiveCoreConfig, PROGRESS_THROTTLE_NANOS, RecordingStats, SegmentErrorMode, ZERO_F64,
+    ZERO_U64,
 };
-use super::{RecordingConfig, hls};
+use super::super::{RecordingConfig, hls};
 use crate::error::{Error, Result};
 use crate::events::DownloadEvent;
 use crate::events::types::RecordingMethod;
@@ -46,16 +47,16 @@ impl LiveRecorder {
     /// * `client` - Shared HTTP client.
     pub fn new(config: RecordingConfig, client: Arc<reqwest::Client>) -> Self {
         Self {
-            core: LiveCore::new(
-                config.stream_url,
-                config.video_id,
-                config.quality,
-                config.max_duration,
-                config.cancellation_token,
+            core: LiveCore::new(LiveCoreConfig {
+                playlist_url: config.stream_url,
+                video_id: config.video_id,
+                quality: config.quality,
+                max_duration: config.max_duration,
+                cancellation_token: config.cancellation_token,
                 client,
-                config.event_bus,
-                Some(config.output_path.clone()),
-            ),
+                event_bus: config.event_bus,
+                output_path: Some(config.output_path.clone()),
+            }),
             output_path: config.output_path,
         }
     }
@@ -74,8 +75,8 @@ impl LiveRecorder {
     ///
     /// # Returns
     ///
-    /// A [`super::RecordingResult`] with recording statistics.
-    pub async fn record(&self) -> Result<super::RecordingResult> {
+    /// A [`super::super::RecordingResult`] with recording statistics.
+    pub async fn record(&self) -> Result<super::super::RecordingResult> {
         if let Some(parent) = self.output_path.parent() {
             fs::create_dir_all(parent).await?;
         }
@@ -95,7 +96,7 @@ impl LiveRecorder {
             "✅ Live recording stopped"
         );
 
-        Ok(super::RecordingResult {
+        Ok(super::super::RecordingResult {
             output_path: self.output_path.clone(),
             total_bytes: stats.total_bytes,
             total_duration: stats.total_duration,
@@ -135,7 +136,8 @@ impl LiveRecorder {
             });
 
         let initial = hls::parse_media(&self.core.client, &self.core.playlist_url).await?;
-        let poll_interval = Duration::from_secs_f64(initial.target_duration / super::core::POLL_INTERVAL_DIVISOR);
+        let poll_interval =
+            Duration::from_secs_f64(initial.target_duration / super::super::core::POLL_INTERVAL_DIVISOR);
 
         for seg in &initial.segments {
             seen_sequences.insert(seg.sequence);

--- a/src/live/streaming.rs
+++ b/src/live/streaming.rs
@@ -9,8 +9,8 @@ use tokio::time;
 use tokio_stream::wrappers::ReceiverStream;
 
 use super::core::{
-    BITS_PER_BYTE, LiveCore, LiveFragment, POLL_INTERVAL_DIVISOR, PROGRESS_THROTTLE_NANOS, RecordingStats,
-    SegmentErrorMode, ZERO_F64, ZERO_U64,
+    BITS_PER_BYTE, LiveCore, LiveCoreConfig, LiveFragment, POLL_INTERVAL_DIVISOR, PROGRESS_THROTTLE_NANOS,
+    RecordingStats, SegmentErrorMode, ZERO_F64, ZERO_U64,
 };
 use super::{LiveStreamConfig, hls};
 use crate::error::Result;
@@ -45,16 +45,16 @@ impl LiveFragmentStreamer {
     /// A new [`LiveFragmentStreamer`] instance.
     pub fn new(config: LiveStreamConfig, client: Arc<reqwest::Client>) -> Self {
         Self {
-            core: LiveCore::new(
-                config.stream_url,
-                config.video_id,
-                config.quality,
-                config.max_duration,
-                config.cancellation_token,
+            core: LiveCore::new(LiveCoreConfig {
+                playlist_url: config.stream_url,
+                video_id: config.video_id,
+                quality: config.quality,
+                max_duration: config.max_duration,
+                cancellation_token: config.cancellation_token,
                 client,
-                config.event_bus,
-                None,
-            ),
+                event_bus: config.event_bus,
+                output_path: None,
+            }),
         }
     }
 

--- a/src/live/streaming.rs
+++ b/src/live/streaming.rs
@@ -1,0 +1,228 @@
+use std::collections::HashSet;
+use std::future::Future;
+use std::sync::Arc;
+use std::sync::atomic::{AtomicU64, Ordering};
+use std::time::{Duration, Instant};
+
+use tokio::sync::mpsc;
+use tokio::time;
+use tokio_stream::wrappers::ReceiverStream;
+
+use super::core::{
+    BITS_PER_BYTE, LiveCore, LiveFragment, POLL_INTERVAL_DIVISOR, PROGRESS_THROTTLE_NANOS, RecordingStats,
+    SegmentErrorMode, ZERO_F64, ZERO_U64,
+};
+use super::{StreamRecordingConfig, hls};
+use crate::error::Result;
+use crate::events::DownloadEvent;
+
+/// Channel capacity for streaming fragments.
+const FRAGMENT_CHANNEL_CAPACITY: usize = 32;
+
+/// Result stream type for live fragment delivery.
+pub type LiveFragmentStream = ReceiverStream<Result<LiveFragment>>;
+
+/// Streamer for live HLS fragments.
+#[derive(Debug)]
+pub struct LiveFragmentStreamer {
+    /// Shared recording state and logic.
+    core: LiveCore,
+}
+
+impl LiveFragmentStreamer {
+    /// Creates a new `LiveFragmentStreamer`.
+    ///
+    /// # Arguments
+    ///
+    /// * `config` - Common streaming configuration (URL, duration, events).
+    /// * `client` - Shared HTTP client.
+    ///
+    /// # Returns
+    ///
+    /// A new [`LiveFragmentStreamer`] instance.
+    pub fn new(config: StreamRecordingConfig, client: Arc<reqwest::Client>) -> Self {
+        Self {
+            core: LiveCore::new(
+                config.stream_url,
+                config.video_id,
+                config.quality,
+                config.max_duration,
+                config.cancellation_token,
+                client,
+                config.event_bus,
+                None,
+            ),
+        }
+    }
+
+    /// Starts streaming fragments from the live stream.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if the playlist or any segment cannot be fetched.
+    ///
+    /// # Returns
+    ///
+    /// A [`LiveFragmentStream`] that yields fragments as they arrive.
+    pub async fn stream(&self) -> Result<LiveFragmentStream> {
+        let (sender, receiver) = mpsc::channel(FRAGMENT_CHANNEL_CAPACITY);
+        let core = self.core.clone();
+
+        tokio::spawn(async move {
+            let result = run_loop(
+                core.clone(),
+                |fragment| async {
+                    if sender.send(Ok(fragment)).await.is_err() {
+                        core.cancellation_token.cancel();
+                        return Ok(());
+                    }
+                    Ok(())
+                },
+                || async { Ok(()) },
+            )
+            .await;
+
+            if let Err(error) = result {
+                core.event_bus.emit_if_subscribed(DownloadEvent::LiveStreamFailed {
+                    video_id: core.video_id.clone(),
+                    error: error.to_string(),
+                });
+                let _ = sender.send(Err(error)).await;
+            }
+        });
+
+        Ok(ReceiverStream::new(receiver))
+    }
+}
+
+async fn run_loop<F, Fut, B, BFut>(core: LiveCore, mut on_fragment: F, mut on_batch: B) -> Result<RecordingStats>
+where
+    F: FnMut(LiveFragment) -> Fut,
+    Fut: Future<Output = Result<()>>,
+    B: FnMut() -> BFut,
+    BFut: Future<Output = Result<()>>,
+{
+    let start = Instant::now();
+    let bytes_written = Arc::new(AtomicU64::new(ZERO_U64));
+    let mut segments_downloaded: u64 = ZERO_U64;
+    let mut seen_sequences: HashSet<u64> = HashSet::new();
+    let mut last_progress_nanos: u64 = ZERO_U64;
+
+    tracing::info!(
+        url = core.playlist_url,
+        video_id = core.video_id,
+        max_duration = ?core.max_duration,
+        "📥 Starting live streaming (reqwest)"
+    );
+
+    core.event_bus.emit_if_subscribed(DownloadEvent::LiveStreamStarted {
+        video_id: core.video_id.clone(),
+        url: core.playlist_url.clone(),
+        quality: core.quality.clone(),
+    });
+
+    let initial = hls::parse_media(&core.client, &core.playlist_url).await?;
+    let poll_interval = Duration::from_secs_f64(initial.target_duration / POLL_INTERVAL_DIVISOR);
+
+    for seg in &initial.segments {
+        seen_sequences.insert(seg.sequence);
+    }
+
+    for seg in &initial.segments {
+        if core.cancellation_token.is_cancelled() {
+            break;
+        }
+        let fragment = core.fetch_fragment(seg, SegmentErrorMode::Streaming).await?;
+        bytes_written.fetch_add(fragment.data.len() as u64, Ordering::Relaxed);
+        segments_downloaded += 1;
+        on_fragment(fragment).await?;
+    }
+    on_batch().await?;
+
+    let stop_reason = loop {
+        if let Some(max) = core.max_duration
+            && start.elapsed() >= max
+        {
+            break "max duration reached".to_string();
+        }
+
+        tokio::select! {
+            _ = core.cancellation_token.cancelled() => {
+                break "cancelled".to_string();
+            }
+            _ = time::sleep(poll_interval) => {}
+        }
+
+        let playlist = match hls::parse_media(&core.client, &core.playlist_url).await {
+            Ok(p) => p,
+            Err(e) => {
+                tracing::warn!(error = %e, "HLS playlist fetch failed, retrying next cycle");
+                continue;
+            }
+        };
+
+        if playlist.is_endlist && playlist.segments.iter().all(|s| seen_sequences.contains(&s.sequence)) {
+            break "stream ended".to_string();
+        }
+
+        let new_segments: Vec<_> = playlist
+            .segments
+            .iter()
+            .filter(|s| !seen_sequences.contains(&s.sequence))
+            .collect();
+
+        for seg in &new_segments {
+            if core.cancellation_token.is_cancelled() {
+                break;
+            }
+
+            let fragment = core.fetch_fragment(seg, SegmentErrorMode::Streaming).await?;
+            bytes_written.fetch_add(fragment.data.len() as u64, Ordering::Relaxed);
+            segments_downloaded += 1;
+            seen_sequences.insert(seg.sequence);
+            on_fragment(fragment).await?;
+        }
+        on_batch().await?;
+
+        let now_nanos = start.elapsed().as_nanos() as u64;
+        if now_nanos - last_progress_nanos >= PROGRESS_THROTTLE_NANOS {
+            last_progress_nanos = now_nanos;
+            let total_bytes = bytes_written.load(Ordering::Relaxed);
+            let elapsed = start.elapsed();
+            let bitrate_bps = if elapsed.as_secs_f64() > ZERO_F64 {
+                (total_bytes as f64 * BITS_PER_BYTE) / elapsed.as_secs_f64()
+            } else {
+                ZERO_F64
+            };
+
+            core.event_bus.emit_if_subscribed(DownloadEvent::LiveStreamProgress {
+                video_id: core.video_id.clone(),
+                elapsed,
+                bytes_received: total_bytes,
+                segments: segments_downloaded,
+                bitrate_bps,
+            });
+        }
+
+        if playlist.is_endlist {
+            break "stream ended".to_string();
+        }
+    };
+
+    let total_duration = start.elapsed();
+    let total_bytes = bytes_written.load(Ordering::Relaxed);
+
+    core.event_bus.emit_if_subscribed(DownloadEvent::LiveStreamStopped {
+        video_id: core.video_id.clone(),
+        reason: stop_reason.clone(),
+        total_bytes,
+        total_duration,
+    });
+
+    Ok(RecordingStats {
+        total_bytes,
+        total_duration,
+        segments_downloaded,
+        stop_reason,
+    })
+}

--- a/src/live/streaming.rs
+++ b/src/live/streaming.rs
@@ -12,7 +12,7 @@ use super::core::{
     BITS_PER_BYTE, LiveCore, LiveFragment, POLL_INTERVAL_DIVISOR, PROGRESS_THROTTLE_NANOS, RecordingStats,
     SegmentErrorMode, ZERO_F64, ZERO_U64,
 };
-use super::{StreamRecordingConfig, hls};
+use super::{LiveStreamConfig, hls};
 use crate::error::Result;
 use crate::events::DownloadEvent;
 
@@ -43,7 +43,7 @@ impl LiveFragmentStreamer {
     /// # Returns
     ///
     /// A new [`LiveFragmentStreamer`] instance.
-    pub fn new(config: StreamRecordingConfig, client: Arc<reqwest::Client>) -> Self {
+    pub fn new(config: LiveStreamConfig, client: Arc<reqwest::Client>) -> Self {
         Self {
             core: LiveCore::new(
                 config.stream_url,

--- a/src/live/streaming.rs
+++ b/src/live/streaming.rs
@@ -1,4 +1,4 @@
-use std::collections::HashSet;
+use std::collections::{HashSet, VecDeque};
 use std::future::Future;
 use std::sync::Arc;
 use std::sync::atomic::{AtomicU64, Ordering};
@@ -18,6 +18,9 @@ use crate::events::DownloadEvent;
 
 /// Channel capacity for streaming fragments.
 const FRAGMENT_CHANNEL_CAPACITY: usize = 32;
+
+/// Maximum sequence numbers to track for duplicate suppression.
+const SEQUENCE_TRACK_WINDOW: usize = 512;
 
 /// Result stream type for live fragment delivery.
 pub type LiveFragmentStream = ReceiverStream<Result<LiveFragment>>;
@@ -59,18 +62,23 @@ impl LiveFragmentStreamer {
     ///
     /// # Errors
     ///
-    /// Returns an error if the playlist or any segment cannot be fetched.
+    /// Returns an error if the initial playlist cannot be fetched.
     ///
     /// # Returns
     ///
     /// A [`LiveFragmentStream`] that yields fragments as they arrive.
     pub async fn stream(&self) -> Result<LiveFragmentStream> {
+        let initial = hls::parse_media(&self.core.client, &self.core.playlist_url).await?;
+        let poll_interval = Duration::from_secs_f64(initial.target_duration / POLL_INTERVAL_DIVISOR);
+
         let (sender, receiver) = mpsc::channel(FRAGMENT_CHANNEL_CAPACITY);
         let core = self.core.clone();
 
         tokio::spawn(async move {
             let result = run_loop(
                 core.clone(),
+                initial,
+                poll_interval,
                 |fragment| async {
                     if sender.send(Ok(fragment)).await.is_err() {
                         core.cancellation_token.cancel();
@@ -95,7 +103,13 @@ impl LiveFragmentStreamer {
     }
 }
 
-async fn run_loop<F, Fut, B, BFut>(core: LiveCore, mut on_fragment: F, mut on_batch: B) -> Result<RecordingStats>
+async fn run_loop<F, Fut, B, BFut>(
+    core: LiveCore,
+    initial: hls::HlsPlaylist,
+    poll_interval: Duration,
+    mut on_fragment: F,
+    mut on_batch: B,
+) -> Result<RecordingStats>
 where
     F: FnMut(LiveFragment) -> Fut,
     Fut: Future<Output = Result<()>>,
@@ -106,6 +120,7 @@ where
     let bytes_written = Arc::new(AtomicU64::new(ZERO_U64));
     let mut segments_downloaded: u64 = ZERO_U64;
     let mut seen_sequences: HashSet<u64> = HashSet::new();
+    let mut sequence_window: VecDeque<u64> = VecDeque::new();
     let mut last_progress_nanos: u64 = ZERO_U64;
 
     tracing::info!(
@@ -121,11 +136,8 @@ where
         quality: core.quality.clone(),
     });
 
-    let initial = hls::parse_media(&core.client, &core.playlist_url).await?;
-    let poll_interval = Duration::from_secs_f64(initial.target_duration / POLL_INTERVAL_DIVISOR);
-
     for seg in &initial.segments {
-        seen_sequences.insert(seg.sequence);
+        track_sequence(seg.sequence, &mut seen_sequences, &mut sequence_window);
     }
 
     for seg in &initial.segments {
@@ -135,6 +147,7 @@ where
         let fragment = core.fetch_fragment(seg, SegmentErrorMode::Streaming).await?;
         bytes_written.fetch_add(fragment.data.len() as u64, Ordering::Relaxed);
         segments_downloaded += 1;
+        track_sequence(seg.sequence, &mut seen_sequences, &mut sequence_window);
         on_fragment(fragment).await?;
     }
     on_batch().await?;
@@ -179,7 +192,7 @@ where
             let fragment = core.fetch_fragment(seg, SegmentErrorMode::Streaming).await?;
             bytes_written.fetch_add(fragment.data.len() as u64, Ordering::Relaxed);
             segments_downloaded += 1;
-            seen_sequences.insert(seg.sequence);
+            track_sequence(seg.sequence, &mut seen_sequences, &mut sequence_window);
             on_fragment(fragment).await?;
         }
         on_batch().await?;
@@ -225,4 +238,16 @@ where
         segments_downloaded,
         stop_reason,
     })
+}
+
+fn track_sequence(sequence: u64, seen: &mut HashSet<u64>, window: &mut VecDeque<u64>) {
+    if seen.insert(sequence) {
+        window.push_back(sequence);
+    }
+
+    while window.len() > SEQUENCE_TRACK_WINDOW {
+        if let Some(evicted) = window.pop_front() {
+            seen.remove(&evicted);
+        }
+    }
 }

--- a/src/model/video.rs
+++ b/src/model/video.rs
@@ -11,7 +11,7 @@ use serde_with::{DefaultOnNull, serde_as};
 
 use crate::model::caption::{AutomaticCaption, Subtitle};
 use crate::model::chapter::Chapter;
-#[cfg(feature = "live-recording")]
+#[cfg(any(feature = "live-recording", feature = "live-streaming"))]
 use crate::model::format::Protocol;
 use crate::model::format::{Format, FormatType};
 use crate::model::heatmap::Heatmap;
@@ -59,7 +59,7 @@ pub struct Video {
     pub release_timestamp: Option<i64>,
     /// Release year, if different from the upload year.
     pub release_year: Option<i64>,
-    #[cfg(feature = "live-recording")]
+    #[cfg(any(feature = "live-recording", feature = "live-streaming"))]
     /// The number of concurrent viewers (live streams only).
     pub concurrent_view_count: Option<i64>,
 
@@ -355,7 +355,7 @@ impl Video {
     /// # Returns
     ///
     /// `true` if the video is currently being broadcast live.
-    #[cfg(feature = "live-recording")]
+    #[cfg(any(feature = "live-recording", feature = "live-streaming"))]
     pub fn is_currently_live(&self) -> bool {
         const STATUS: &str = "is_live";
 
@@ -367,7 +367,7 @@ impl Video {
     /// # Returns
     ///
     /// `true` if the video is scheduled but has not started yet.
-    #[cfg(feature = "live-recording")]
+    #[cfg(any(feature = "live-recording", feature = "live-streaming"))]
     pub fn is_upcoming(&self) -> bool {
         const STATUS: &str = "is_upcoming";
 
@@ -382,7 +382,7 @@ impl Video {
     /// # Returns
     ///
     /// A vector of references to HLS formats, sorted by total bitrate (ascending).
-    #[cfg(feature = "live-recording")]
+    #[cfg(any(feature = "live-recording", feature = "live-streaming"))]
     pub fn live_formats(&self) -> Vec<&Format> {
         let mut formats: Vec<&Format> = self
             .formats

--- a/src/prelude.rs
+++ b/src/prelude.rs
@@ -30,10 +30,11 @@ pub use crate::events::{EventHook, HookRegistry};
 #[cfg(feature = "webhooks")]
 pub use crate::events::{RetryStrategy, WebhookConfig, WebhookDelivery};
 #[cfg(feature = "live-recording")]
-pub use crate::live::{
-    FfmpegLiveRecorder, HlsPlaylist, HlsSegment, HlsVariant, LiveFragment, LiveFragmentStream, LiveFragmentStreamer,
-    LiveRecorder, LiveRecordingBuilder, LiveStreamBuilder, RecordingResult,
-};
+pub use crate::live::{FfmpegLiveRecorder, LiveRecorder, LiveRecordingBuilder, RecordingResult};
+#[cfg(any(feature = "live-recording", feature = "live-streaming"))]
+pub use crate::live::{HlsPlaylist, HlsSegment, HlsVariant};
+#[cfg(feature = "live-streaming")]
+pub use crate::live::{LiveFragment, LiveFragmentStream, LiveFragmentStreamer, LiveStreamBuilder};
 // Model types
 pub use crate::model::Video;
 pub use crate::model::selector::{

--- a/src/prelude.rs
+++ b/src/prelude.rs
@@ -31,7 +31,8 @@ pub use crate::events::{EventHook, HookRegistry};
 pub use crate::events::{RetryStrategy, WebhookConfig, WebhookDelivery};
 #[cfg(feature = "live-recording")]
 pub use crate::live::{
-    FfmpegLiveRecorder, HlsPlaylist, HlsSegment, HlsVariant, LiveRecorder, LiveRecordingBuilder, RecordingResult,
+    FfmpegLiveRecorder, HlsPlaylist, HlsSegment, HlsVariant, LiveFragment, LiveFragmentStream, LiveFragmentStreamer,
+    LiveRecorder, LiveRecordingBuilder, LiveStreamBuilder, RecordingResult,
 };
 // Model types
 pub use crate::model::Video;

--- a/src/stats/tracker.rs
+++ b/src/stats/tracker.rs
@@ -454,7 +454,11 @@ fn handle_event(state: &mut StatsInner, event: &DownloadEvent) {
         DownloadEvent::LiveRecordingStarted { .. }
         | DownloadEvent::LiveRecordingProgress { .. }
         | DownloadEvent::LiveRecordingStopped { .. }
-        | DownloadEvent::LiveRecordingFailed { .. } => {
+        | DownloadEvent::LiveRecordingFailed { .. }
+        | DownloadEvent::LiveStreamStarted { .. }
+        | DownloadEvent::LiveStreamProgress { .. }
+        | DownloadEvent::LiveStreamStopped { .. }
+        | DownloadEvent::LiveStreamFailed { .. } => {
             tracing::debug!(event = ?event, "📊 Live recording event, ignoring in stats");
         }
     }

--- a/src/stats/tracker.rs
+++ b/src/stats/tracker.rs
@@ -454,12 +454,15 @@ fn handle_event(state: &mut StatsInner, event: &DownloadEvent) {
         DownloadEvent::LiveRecordingStarted { .. }
         | DownloadEvent::LiveRecordingProgress { .. }
         | DownloadEvent::LiveRecordingStopped { .. }
-        | DownloadEvent::LiveRecordingFailed { .. }
-        | DownloadEvent::LiveStreamStarted { .. }
+        | DownloadEvent::LiveRecordingFailed { .. } => {
+            tracing::debug!(event = ?event, "📊 Live recording event, ignoring in stats");
+        }
+        #[cfg(feature = "live-streaming")]
+        DownloadEvent::LiveStreamStarted { .. }
         | DownloadEvent::LiveStreamProgress { .. }
         | DownloadEvent::LiveStreamStopped { .. }
         | DownloadEvent::LiveStreamFailed { .. } => {
-            tracing::debug!(event = ?event, "📊 Live recording event, ignoring in stats");
+            tracing::debug!(event = ?event, "📊 Live stream event, ignoring in stats");
         }
     }
 }

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -55,6 +55,10 @@ mod builder;
 #[path = "integration/live/recording.rs"]
 mod live_recording;
 
+#[cfg(feature = "live-streaming")]
+#[path = "integration/live/streaming.rs"]
+mod live_streaming;
+
 #[path = "integration/media-seek/mod.rs"]
 mod media_seek;
 

--- a/tests/integration/live/streaming.rs
+++ b/tests/integration/live/streaming.rs
@@ -1,0 +1,76 @@
+use std::sync::Arc;
+use std::time::Duration;
+
+use tokio_stream::StreamExt;
+use tokio_util::sync::CancellationToken;
+use wiremock::matchers::{method, path, path_regex};
+use wiremock::{Mock, MockServer, ResponseTemplate};
+use yt_dlp::live::{LiveFragmentStreamer, StreamRecordingConfig};
+
+use crate::common;
+
+/// Sets up a wiremock server serving HLS master + media playlists and segments.
+async fn setup_hls_server() -> MockServer {
+    let server = MockServer::start().await;
+
+    let master_content = common::fixtures::load_hls_fixture("master.m3u8", &server.uri());
+    Mock::given(method("GET"))
+        .and(path("/hls/master.m3u8"))
+        .respond_with(
+            ResponseTemplate::new(200)
+                .set_body_string(master_content)
+                .insert_header("Content-Type", "application/vnd.apple.mpegurl"),
+        )
+        .mount(&server)
+        .await;
+
+    let media_content = common::fixtures::load_hls_fixture("media.m3u8", &server.uri());
+    Mock::given(method("GET"))
+        .and(path_regex(r"^/hls/.*\.m3u8$"))
+        .respond_with(
+            ResponseTemplate::new(200)
+                .set_body_string(media_content)
+                .insert_header("Content-Type", "application/vnd.apple.mpegurl"),
+        )
+        .mount(&server)
+        .await;
+
+    let segment_bytes = common::fixtures::load_media_bytes("small.ts");
+    Mock::given(method("GET"))
+        .and(path_regex(r"^/hls/segment_\d+\.ts$"))
+        .respond_with(
+            ResponseTemplate::new(200)
+                .set_body_bytes(segment_bytes)
+                .insert_header("Content-Type", "video/mp2t"),
+        )
+        .mount(&server)
+        .await;
+
+    server
+}
+
+#[tokio::test]
+async fn stream_live_fragments_yields_segments() {
+    let server = setup_hls_server().await;
+    let client = Arc::new(reqwest::Client::new());
+    let cancellation_token = CancellationToken::new();
+
+    let config = StreamRecordingConfig {
+        stream_url: format!("{}/hls/720p.m3u8", server.uri()),
+        video_id: "test_video".to_string(),
+        quality: "720p".to_string(),
+        max_duration: Some(Duration::from_secs(1)),
+        cancellation_token: cancellation_token.clone(),
+        event_bus: yt_dlp::events::EventBus::with_default_capacity(),
+    };
+
+    let streamer = LiveFragmentStreamer::new(config, client);
+    let mut stream = streamer.stream().await.expect("stream should start");
+
+    let first = stream.next().await.expect("expected first fragment");
+    let fragment = first.expect("fragment should be ok");
+    assert!(!fragment.data.is_empty(), "fragment data should not be empty");
+
+    cancellation_token.cancel();
+    let _ = stream.next().await;
+}

--- a/tests/integration/live/streaming.rs
+++ b/tests/integration/live/streaming.rs
@@ -5,7 +5,7 @@ use tokio_stream::StreamExt;
 use tokio_util::sync::CancellationToken;
 use wiremock::matchers::{method, path, path_regex};
 use wiremock::{Mock, MockServer, ResponseTemplate};
-use yt_dlp::live::{LiveFragmentStreamer, StreamRecordingConfig};
+use yt_dlp::live::{LiveFragmentStreamer, LiveStreamConfig};
 
 use crate::common;
 
@@ -55,7 +55,7 @@ async fn stream_live_fragments_yields_segments() {
     let client = Arc::new(reqwest::Client::new());
     let cancellation_token = CancellationToken::new();
 
-    let config = StreamRecordingConfig {
+    let config = LiveStreamConfig {
         stream_url: format!("{}/hls/720p.m3u8", server.uri()),
         video_id: "test_video".to_string(),
         quality: "720p".to_string(),

--- a/tests/unit.rs
+++ b/tests/unit.rs
@@ -16,7 +16,7 @@ mod extractor;
 mod ffmpeg_args;
 #[path = "unit/utils/fs_utils.rs"]
 mod fs_utils;
-#[cfg(feature = "live-recording")]
+#[cfg(any(feature = "live-recording", feature = "live-streaming"))]
 #[path = "unit/live/hls_parsing.rs"]
 mod hls_parsing;
 #[path = "unit/media-seek/mod.rs"]


### PR DESCRIPTION
## Summary
This PR adds live fragment streaming support alongside the existing live recording workflow. It introduces a dedicated streaming API, emits streaming-specific events, and reorganizes the live code into clearer, smaller modules. Documentation and contributor guidance are updated to reflect the new live streaming capability.

## Changes
### Live streaming API
- `LiveStreamBuilder` entrypoint on `Downloader` for streaming live HLS fragments
- `LiveFragmentStreamer` + `LiveFragmentStream` for streaming segment data to consumers
- `LiveFragment` struct for per-segment payloads (sequence, duration, URL, bytes)

### Events & stats
- new streaming lifecycle/progress events: `LiveStreamStarted`, `LiveStreamProgress`, `LiveStreamStopped`, `LiveStreamFailed`
- progress detection updated to include streaming events when enabled
- stats tracker ignores streaming events (consistent with recording events)
- new `EventFilter::only_live_streaming()` helper

### Errors
- new live streaming error variant + constructor
- HLS parsing and live availability errors usable by both recording and streaming

### Module layout
- shared live logic moved into `live/core.rs`
- recording logic isolated to `live/recording.rs`
- streaming logic isolated to `live/streaming.rs`

### Feature gating & exports
- streaming is gated behind `live-streaming`
- recording remains behind `live-recording`
- `prelude` exports updated to match feature gates

### Docs & guidance
- README feature list and live sections updated
- CONTRIBUTING.md checklist updated for combined live features
- CLAUDE.md feature notes updated
- docs.rs features include live recording + streaming

## Testing
All checklist commands from CONTRIBUTING.md were run.