### PR TITLE
Adds `requested_formats` to `yt_dlp::model::video::Video`

### DIFF
--- a/src/model/video.rs
+++ b/src/model/video.rs
@@ -91,6 +91,9 @@ pub struct Video {
     /// The available formats of the video.
     #[serde(default)]
     pub formats: Vec<Format>,
+    /// The requested (defaults to the best) formats of the video.
+    #[serde(default)]
+    pub requested_formats: Vec<Format>,
     /// The thumbnails of the video.
     #[serde(default)]
     pub thumbnails: Vec<Thumbnail>,


### PR DESCRIPTION
This PR introduces a new field `requested_formats` to `yt_dlp::model::video::Video`. This field contains the specific `Format`s that are selected for download, such as the best video + audio pair (e.g., `399` and `251`). It complements the existing `formats` field, which lists all available `formats`.

Closes: #179