### PR TITLE
🦀 [Rust Crates] Update lofty and paste dependencies

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1491,8 +1491,9 @@ dependencies = [
 
 [[package]]
 name = "lofty"
-version = "0.23.3"
-source = "git+https://github.com/boul2gom/lofty-rs#d2e41640481a48a95303d95939ba831767afcec8"
+version = "0.24.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dec4feeff6c7d75093278133a06e827d7af6d2bfe20b0f331f9d10338a5ec7ca"
 dependencies = [
  "byteorder",
  "data-encoding",
@@ -1500,13 +1501,14 @@ dependencies = [
  "lofty_attr",
  "log",
  "ogg_pager",
- "pastey",
+ "paste",
 ]
 
 [[package]]
 name = "lofty_attr"
 version = "0.12.0"
-source = "git+https://github.com/boul2gom/lofty-rs#d2e41640481a48a95303d95939ba831767afcec8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "458ace39169e4b83c4f77ae3d42d5d1d11c422feef590219a97c973d3b524557"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1711,7 +1713,8 @@ dependencies = [
 [[package]]
 name = "ogg_pager"
 version = "0.7.1"
-source = "git+https://github.com/boul2gom/lofty-rs#d2e41640481a48a95303d95939ba831767afcec8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6d6d1ca8364b84e0cf725eed06b1460c44671e6c0fb28765f5262de3ece07fdc"
 dependencies = [
  "byteorder",
 ]
@@ -1779,10 +1782,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "pastey"
-version = "0.2.1"
+name = "paste"
+version = "1.0.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b867cad97c0791bbd3aaa6472142568c6c9e8f71937e98379f584cfb0cf35bec"
+checksum = "57c0d7b74b563b49d38dae00a0c37d4d6de9b432382b2892f0574ddcae73fd0a"
 
 [[package]]
 name = "percent-encoding"
@@ -3894,3 +3897,8 @@ dependencies = [
  "log",
  "simd-adler32",
 ]
+
+[[patch.unused]]
+name = "lofty"
+version = "0.23.3"
+source = "git+https://github.com/boul2gom/lofty-rs#d2e41640481a48a95303d95939ba831767afcec8"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -108,7 +108,7 @@ thiserror = "2.0.18"
 m3u8-rs = { version = "6.0.0", optional = true }
 mp4ameta = "0.13.0"
 id3 = "1.16.4"
-lofty = "0.23.2"
+lofty = "0.24.0"
 
 # Compression and archives
 zip = { version = "8.5.1", default-features = false, features = ["deflate"] }


### PR DESCRIPTION
- Bump lofty from 0.23.2 to 0.24.0