### PR TITLE
Update lofty dependency version to 0.24.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -108,7 +108,7 @@ thiserror = "2.0.18"
 m3u8-rs = { version = "6.0.0", optional = true }
 mp4ameta = "0.13.0"
 id3 = "1.16.4"
-lofty = "0.23.2"
+lofty = "0.24.0"
 
 # Compression and archives
 zip = { version = "8.5.1", default-features = false, features = ["deflate"] }


### PR DESCRIPTION
The package cannot be installed anymore without this fix. 