### PR TITLE
Handle empty title

### DIFF
--- a/src/model/types/playlist.rs
+++ b/src/model/types/playlist.rs
@@ -5,6 +5,7 @@ use std::hash::{Hash, Hasher};
 use std::path::PathBuf;
 
 use serde::{Deserialize, Serialize};
+use serde_with::{DefaultOnNull, serde_as};
 
 /// Represents a YouTube playlist.
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -208,11 +209,13 @@ impl Playlist {
 }
 
 /// Represents an entry (video) in a playlist.
+#[serde_as]
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct PlaylistEntry {
     /// The video ID.
     pub id: String,
     /// The video title.
+    #[serde_as(deserialize_as = "DefaultOnNull")]
     pub title: String,
     /// The video URL.
     pub url: String,


### PR DESCRIPTION
Fixes #212.

This PR makes private videos, videos that have been deleted, or videos created by channels that have been deleted, have a title of `""`.
This is an improvement over the current situation, which fails to parse any json output of `yt-dlp` where the video title is `null`.
I also considered making `title` an `Option<String>`, but that would break any users who rely on this field being a `String`.